### PR TITLE
annotations, proof rule encodings, specty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "pretty",
+ "pretty_assertions",
  "proptest",
  "ref-cast",
  "replace_with",
@@ -1344,6 +1345,16 @@ dependencies = [
  "log",
  "typed-arena",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ lit = "1.0"
 clap = "2.33"
 glob = "0.3"
 proptest = "1.0"
+pretty_assertions = "1.4.0"
 
 [[test]]
 name = "integration"

--- a/src/ast/decl.rs
+++ b/src/ast/decl.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    intrinsic::{FuncIntrin, ProcIntrin},
+    intrinsic::{annotations::AnnotationKind, FuncIntrin, ProcIntrin},
     pretty::{parens_group, pretty_block, Doc, SimplePretty},
 };
 
@@ -27,6 +27,7 @@ pub enum DeclKind {
     ProcIntrin(Rc<dyn ProcIntrin>),
     FuncIntrin(Rc<dyn FuncIntrin>),
     LabelDecl(Ident),
+    AnnotationDecl(AnnotationKind),
 }
 
 impl DeclKind {
@@ -42,6 +43,7 @@ impl DeclKind {
             DeclKind::ProcIntrin(proc_intrin) => proc_intrin.name(),
             DeclKind::FuncIntrin(func_intrin) => func_intrin.name(),
             DeclKind::LabelDecl(ident) => *ident,
+            DeclKind::AnnotationDecl(anno_intrin) => anno_intrin.name(),
         }
     }
 }
@@ -54,12 +56,12 @@ impl SimplePretty for DeclKind {
             DeclKind::DomainDecl(domain_decl) => domain_decl.pretty(),
             DeclKind::FuncDecl(func_decl) => func_decl.pretty(),
             DeclKind::AxiomDecl(axiom_decl) => axiom_decl.pretty(),
-            DeclKind::ProcIntrin(proc_intrin) => Doc::text("instrinsic")
+            DeclKind::ProcIntrin(proc_intrin) => Doc::text("intrinsic")
                 .append(Doc::space())
                 .append(Doc::text("proc"))
                 .append(Doc::space())
                 .append(Doc::as_string(proc_intrin.name().name)),
-            DeclKind::FuncIntrin(fn_intrin) => Doc::text("instrinsic")
+            DeclKind::FuncIntrin(fn_intrin) => Doc::text("intrinsic")
                 .append(Doc::space())
                 .append(Doc::text("fn"))
                 .append(Doc::space())
@@ -67,6 +69,11 @@ impl SimplePretty for DeclKind {
             DeclKind::LabelDecl(ident) => Doc::text("label")
                 .append(Doc::space())
                 .append(Doc::as_string(ident.name)),
+            DeclKind::AnnotationDecl(anno_intrin) => Doc::text("intrinsic")
+                .append(Doc::space())
+                .append(Doc::text("annotation"))
+                .append(Doc::space())
+                .append(Doc::as_string(anno_intrin.name().name)),
         }
     }
 }
@@ -281,6 +288,7 @@ impl SimplePretty for ProcDecl {
 pub struct Param {
     pub name: Ident,
     pub ty: Box<TyKind>,
+    pub literal_only: bool,
     pub span: Span,
 }
 

--- a/src/ast/diagnostic.rs
+++ b/src/ast/diagnostic.rs
@@ -24,6 +24,7 @@ impl FileId {
 pub enum SourceFilePath {
     Path(PathBuf),
     Builtin,
+    Generated,
 }
 
 impl SourceFilePath {
@@ -37,6 +38,7 @@ impl SourceFilePath {
                 Ok(SourceFilePath::Path(path_buf))
             }
             SourceFilePath::Builtin => Ok(SourceFilePath::Builtin),
+            SourceFilePath::Generated => Ok(SourceFilePath::Generated),
         }
     }
 
@@ -44,6 +46,7 @@ impl SourceFilePath {
         match self {
             SourceFilePath::Path(path) => path.to_string_lossy(),
             SourceFilePath::Builtin => Cow::from("<builtin>"),
+            SourceFilePath::Generated => Cow::from("<generated>"),
         }
     }
 }
@@ -141,6 +144,7 @@ pub enum SpanVariant {
     VC,
     ImplicitCast,
     SpecCall,
+    Encoding,
     Qelim,
     Boolify,
     Subst,
@@ -177,6 +181,15 @@ impl Span {
         }
     }
 
+    pub fn dummy_file_span(file: FileId) -> Self {
+        Span {
+            file,
+            start: 0,
+            end: 0,
+            variant: SpanVariant::Parser,
+        }
+    }
+
     pub fn variant(self, variant: SpanVariant) -> Self {
         Span {
             file: self.file,
@@ -195,6 +208,7 @@ impl fmt::Debug for Span {
             SpanVariant::VC => "vc/",
             SpanVariant::ImplicitCast => "cast/",
             SpanVariant::SpecCall => "spec-call/",
+            SpanVariant::Encoding => "encoding/",
             SpanVariant::Qelim => "qelim/",
             SpanVariant::Boolify => "boolify/",
             SpanVariant::Subst => "subst/",
@@ -218,6 +232,13 @@ impl<T> Spanned<T> {
         Spanned {
             node,
             span: Span::dummy_span(),
+        }
+    }
+
+    pub fn with_dummy_file_span(node: T, file: FileId) -> Self {
+        Spanned {
+            node,
+            span: Span::dummy_file_span(file),
         }
     }
 

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -415,12 +415,13 @@ impl ExprBuilder {
     pub fn call(&self, ident: Ident, args: impl IntoIterator<Item = Expr>, tcx: &TyCtx) -> Expr {
         let decl = tcx.get(ident).unwrap();
         let ty = match decl.as_ref() {
-            DeclKind::FuncDecl(func_ref) => func_ref.borrow().output.clone(),
+            DeclKind::FuncDecl(func_ref) => Some(func_ref.borrow().output.clone()),
+            DeclKind::ProcDecl(_) => None,
             _ => panic!("expected variable declaration"),
         };
         Shared::new(ExprData {
             kind: ExprKind::Call(ident, args.into_iter().collect()),
-            ty: Some(ty),
+            ty,
             span: self.span,
         })
     }

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -91,6 +91,14 @@ impl SimplePretty for StmtKind {
                 .append(Doc::text("}"))
         }
 
+        fn pretty_loop(cond: Doc, body: &Block) -> Doc {
+            Doc::text("while")
+                .append(Doc::space())
+                .append(cond)
+                .append(Doc::space())
+                .append(pretty_block(body.pretty()))
+        }
+
         let res = match self {
             StmtKind::Block(stmts) => pretty_block(stmts.pretty()),
             StmtKind::Var(decl_ref) => {
@@ -120,8 +128,16 @@ impl SimplePretty for StmtKind {
             StmtKind::Demonic(lhs, rhs) => pretty_branch(Doc::text("⊓"), lhs, rhs),
             StmtKind::Angelic(lhs, rhs) => pretty_branch(Doc::text("⊔"), lhs, rhs),
             StmtKind::If(cond, lhs, rhs) => pretty_branch(cond.pretty(), lhs, rhs),
-            StmtKind::While(_, _) => todo!(),
-            StmtKind::Annotation(_, _, _) => todo!(),
+            StmtKind::While(cond, body) => pretty_loop(cond.pretty(), body),
+            StmtKind::Annotation(ident, inputs, stmt) => Doc::text("@")
+                .append(Doc::as_string(ident.name))
+                .append(Doc::text("("))
+                .append(Doc::intersperse(
+                    inputs.iter().map(|expr| expr.pretty()),
+                    Doc::text(", "),
+                ))
+                .append(Doc::text(")"))
+                .append(Doc::line().append(stmt.pretty())),
             StmtKind::Label(ident) => Doc::text("label")
                 .append(Doc::space())
                 .append(Doc::as_string(ident.name)),

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -1,4 +1,5 @@
 use super::Span;
+use crate::ast::FileId;
 use once_cell::sync::Lazy;
 use std::fmt;
 use std::sync::Mutex;
@@ -49,6 +50,13 @@ impl Ident {
         Ident {
             name,
             span: Span::dummy_span(),
+        }
+    }
+
+    pub fn with_dummy_file_span(name: Symbol, file: FileId) -> Ident {
+        Ident {
+            name,
+            span: Span::dummy_file_span(file),
         }
     }
 }

--- a/src/ast/ty.rs
+++ b/src/ast/ty.rs
@@ -25,6 +25,8 @@ pub enum TyKind {
     List(Box<TyKind>),
     /// A domain type.
     Domain(DeclRef<DomainDecl>),
+    /// This is the current TyCtx's spec_ty
+    SpecTy,
     /// A type defined somewhere which is not resolved yet.
     Unresolved(Ident),
     /// A placeholder or an error.
@@ -61,6 +63,7 @@ impl fmt::Debug for TyKind {
             Self::Tuple(arg0) => f.debug_tuple("Tuple").field(arg0).finish(),
             Self::List(arg0) => f.debug_tuple("List").field(arg0).finish(),
             Self::Domain(arg0) => f.debug_tuple("Domain").field(&arg0.borrow().name).finish(),
+            Self::SpecTy => write!(f, "<spec ty>"),
             Self::Unresolved(arg0) => f.debug_tuple("Unresolved").field(arg0).finish(),
             Self::None => write!(f, "None"),
         }
@@ -88,6 +91,7 @@ impl fmt::Display for TyKind {
             }
             Self::List(element_ty) => write!(f, "[]{}", element_ty),
             Self::Domain(arg0) => write!(f, "{}", &arg0.borrow().name),
+            Self::SpecTy => write!(f, "<spec ty>"),
             Self::Unresolved(name) => write!(f, "{}", name),
             Self::None => write!(f, "<none>"),
         }

--- a/src/ast/util.rs
+++ b/src/ast/util.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+// Using [`IndexSet`], which is a HashSet that preserves the insertion order, for deterministic results
+use indexmap::IndexSet;
 
 use super::{
-    visit::{walk_expr, VisitorMut},
-    Expr, ExprKind, Ident,
+    visit::{walk_expr, walk_stmt, VisitorMut},
+    Expr, ExprKind, Ident, StmtKind,
 };
 
 /// Helper to find all free variables in expressions.
@@ -10,12 +11,21 @@ use super::{
 /// Expressions with substitutions in them are not allowed and will lead to a panic!
 #[derive(Debug, Default)]
 pub struct FreeVariableCollector {
-    pub variables: HashSet<Ident>,
+    pub variables: IndexSet<Ident>,
 }
 
 impl FreeVariableCollector {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Collect variables from given [`Expr`] and clear the [`variables`] for further use
+    pub fn collect_and_clear(&mut self, expr: &mut Expr) -> IndexSet<Ident> {
+        self.visit_expr(expr).unwrap();
+        let vars = self.variables.clone();
+        self.variables.clear();
+
+        vars
     }
 }
 
@@ -54,6 +64,50 @@ impl VisitorMut for FreeVariableCollector {
                 )
             }
             _ => walk_expr(self, expr),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+/// Collect modified and declared variables in a [`Stmt`]. Note that modified variables can contain declared variables.
+pub struct ModifiedVariableCollector {
+    /// [`Ident`]s of variables that are declared in the statement
+    pub declared_variables: IndexSet<Ident>,
+    /// [`Ident`]s of variables that are modified in the statement
+    pub modified_variables: IndexSet<Ident>,
+    /// [`Ident`]s of variables that are used in an expression in the statement
+    pub used_variables: IndexSet<Ident>,
+}
+
+impl ModifiedVariableCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl VisitorMut for ModifiedVariableCollector {
+    type Err = ();
+    fn visit_stmt(&mut self, s: &mut super::Stmt) -> Result<(), Self::Err> {
+        match &s.node {
+            StmtKind::Assign(vars, _) => {
+                self.modified_variables.extend(vars);
+            }
+            StmtKind::Var(var) => {
+                self.declared_variables.insert(var.borrow().name);
+            }
+            _ => {}
+        }
+        walk_stmt(self, s)?;
+        Ok(())
+    }
+
+    fn visit_expr(&mut self, e: &mut Expr) -> Result<(), Self::Err> {
+        match &mut e.kind {
+            ExprKind::Var(ident) => {
+                self.used_variables.insert(*ident);
+                Ok(())
+            }
+            _ => walk_expr(self, e),
         }
     }
 }

--- a/src/ast/util.rs
+++ b/src/ast/util.rs
@@ -19,7 +19,7 @@ impl FreeVariableCollector {
         Self::default()
     }
 
-    /// Collect variables from given [`Expr`] and clear the [`variables`] for further use
+    /// Collect variables from given [`Expr`] and clear the variables set for further use
     pub fn collect_and_clear(&mut self, expr: &mut Expr) -> IndexSet<Ident> {
         self.visit_expr(expr).unwrap();
         let vars = self.variables.clone();
@@ -69,7 +69,7 @@ impl VisitorMut for FreeVariableCollector {
 }
 
 #[derive(Debug, Default)]
-/// Collect modified and declared variables in a [`Stmt`]. Note that modified variables can contain declared variables.
+/// Collect modified and declared variables in a statement. Note that modified variables can contain declared variables.
 pub struct ModifiedVariableCollector {
     /// [`Ident`]s of variables that are declared in the statement
     pub declared_variables: IndexSet<Ident>,

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -22,7 +22,9 @@ pub trait VisitorMut: Sized {
             DeclKind::DomainDecl(domain) => self.visit_domain(domain),
             DeclKind::FuncDecl(func) => self.visit_func(func),
             DeclKind::AxiomDecl(axiom) => self.visit_axiom(axiom),
-            DeclKind::ProcIntrin(_) | DeclKind::FuncIntrin(_) => Ok(()),
+            DeclKind::ProcIntrin(_) | DeclKind::FuncIntrin(_) | DeclKind::AnnotationDecl(_) => {
+                Ok(())
+            }
             DeclKind::LabelDecl(ref mut ident) => self.visit_ident(ident),
         }
     }

--- a/src/front/parser/grammar.lalrpop
+++ b/src/front/parser/grammar.lalrpop
@@ -208,7 +208,7 @@ StmtKind: StmtKind = {
     "if" SymCap <block1: Block> "else" <block2: Block> => StmtKind::Demonic(block1, block2),
     "if" SymCup <block1: Block> "else" <block2: Block> => StmtKind::Angelic(block1, block2),
     "if" <cond: Expr> <block1: Block> "else" <block2: Block> => StmtKind::If(cond, block1, block2),
-    "while" "(" <cond: Expr> ")" <block1: Block> => StmtKind::While(cond, block1),
+    "while" <cond: Expr> <block1: Block> => StmtKind::While(cond, block1),
     "@" <ident: Ident> "(" <inputs: Comma<Expr>> ")" <stmt: Stmt> => StmtKind::Annotation(ident, inputs, Box::new(stmt)),
     "label" <ident: Ident> => StmtKind::Label(ident),
 }
@@ -237,7 +237,7 @@ ParamList: Spanned<Vec<Param>> = {
 }
 
 Param: Param = {
-    <l: @L> <name: Ident> ":" <ty: Ty> <r: @R> => Param { name, ty: Box::new(ty), span: span(file, l, r) }
+    <l: @L> <name: Ident> ":" <ty: Ty> <r: @R> => Param { name, ty: Box::new(ty), literal_only: false ,span: span(file, l, r) }
 }
 
 ProcSpec: ProcSpec = {

--- a/src/intrinsic/annotations.rs
+++ b/src/intrinsic/annotations.rs
@@ -1,0 +1,111 @@
+use std::rc::Rc;
+
+use ariadne::ReportKind;
+
+use crate::{
+    ast::{Diagnostic, Expr, Ident, Label, Param, Span, Spanned, Stmt, Symbol},
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    proof_rules::Encoding,
+};
+
+#[derive(Debug, Clone)]
+pub struct AnnotationInfo {
+    pub name: Ident,
+    pub inputs: Spanned<Vec<Param>>,
+    pub span: Span,
+}
+
+#[derive(Debug)]
+pub enum AnnotationError {
+    NotInProcedure(Span, Ident),
+    NotOnWhile(Span, Ident, Stmt),
+    WrongArgument(Span, Expr, String),
+    OneLoopOnly(Span, Ident),
+}
+
+impl AnnotationError {
+    pub fn diagnostic(self) -> Diagnostic {
+        match self {
+            AnnotationError::NotInProcedure(span, annotation) => {
+                Diagnostic::new(ReportKind::Error, span)
+                    .with_message(format!(
+                        "The annotation `{}` is not in a procedure",
+                        annotation
+                    ))
+                    .with_label(
+                        Label::new(annotation.span).with_message("This should be in a procedure"),
+                    )
+            }
+            AnnotationError::NotOnWhile(span, annotation, annotated) => {
+                Diagnostic::new(ReportKind::Error, span)
+                    .with_message(format!(
+                        "The annotation `{}` is not on a while statement",
+                        annotation
+                    ))
+                    .with_label(
+                        Label::new(annotated.span).with_message("This should be a while statement"),
+                    )
+            }
+            AnnotationError::WrongArgument(span, arg, message) => {
+                Diagnostic::new(ReportKind::Error, span)
+                    .with_message(format!("The argument {} is invalid.", arg))
+                    .with_label(Label::new(arg.span).with_message(message))
+            }
+            AnnotationError::OneLoopOnly(span,encoding_name) => Diagnostic::new(ReportKind::Error, span)
+                .with_message(format!(
+                    "The '{}' encoding only supports programs that consists of only one loop and no other statements, other than variable declarations.",
+                    encoding_name.name
+                ))
+                .with_label(Label::new(span).with_message("There shouldn't be any statements, other than variable declarations, before or after this annotated loop.")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AnnotationKind {
+    Encoding(Rc<dyn Encoding>),
+}
+
+impl AnnotationKind {
+    pub fn name(&self) -> Ident {
+        match self {
+            AnnotationKind::Encoding(encoding) => encoding.name(),
+        }
+    }
+
+    pub fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        match self {
+            AnnotationKind::Encoding(encoding) => encoding.tycheck(tycheck, call_span, args),
+        }
+    }
+
+    pub fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        match self {
+            AnnotationKind::Encoding(encoding) => encoding.resolve(resolve, call_span, args),
+        }
+    }
+}
+
+/// Typecheck annotation call
+pub fn check_annotation_call(
+    tycheck: &mut Tycheck<'_>,
+    span: Span,
+    annotation: &AnnotationInfo,
+    args: &mut [Expr],
+) -> Result<(), TycheckError> {
+    tycheck.check_call(span, &annotation.inputs.node, args)?;
+    Ok(())
+}

--- a/src/intrinsic/annotations.rs
+++ b/src/intrinsic/annotations.rs
@@ -1,9 +1,10 @@
+//! Intrinsic annotations 
 use std::rc::Rc;
 
 use ariadne::ReportKind;
 
 use crate::{
-    ast::{Diagnostic, Expr, Ident, Label, Param, Span, Spanned, Stmt, Symbol},
+    ast::{Diagnostic, Expr, Ident, Label, Param, Span, Spanned, Stmt},
     front::{
         resolve::{Resolve, ResolveError},
         tycheck::{Tycheck, TycheckError},
@@ -56,7 +57,7 @@ impl AnnotationError {
             }
             AnnotationError::OneLoopOnly(span,encoding_name) => Diagnostic::new(ReportKind::Error, span)
                 .with_message(format!(
-                    "The '{}' encoding only supports programs that consists of only one loop and no other statements, other than variable declarations.",
+                    "The '{}' encoding is only supported for programs that consists of only one loop and no other statements, other than variable declarations.",
                     encoding_name.name
                 ))
                 .with_label(Label::new(span).with_message("There shouldn't be any statements, other than variable declarations, before or after this annotated loop.")),

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -4,7 +4,9 @@
 //!
 //! This module provides a framework to define intrinsics in a modular way.
 
+pub mod annotations;
 pub mod distributions;
+
 pub mod list;
 
 use std::fmt;

--- a/src/proof_rules/enc_call.rs
+++ b/src/proof_rules/enc_call.rs
@@ -1,0 +1,543 @@
+//! Replacement of calls to procedures by their specification.
+
+use std::rc::Rc;
+
+use crate::{
+    ast::{visit::VisitorMut, DeclKind, Direction, SourceFilePath, Span, Stmt, StmtKind},
+    driver::{Item, SourceUnit},
+    intrinsic::annotations::{AnnotationError, AnnotationKind},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+pub struct EncCall<'tcx, 'sunit> {
+    tcx: &'tcx mut TyCtx,
+    source_units_buf: &'sunit mut Vec<Item<SourceUnit>>,
+    direction: Option<Direction>,
+}
+
+impl<'tcx, 'sunit> EncCall<'tcx, 'sunit> {
+    pub fn new(tcx: &'tcx mut TyCtx, source_units_buf: &'sunit mut Vec<Item<SourceUnit>>) -> Self {
+        EncCall {
+            tcx,
+            source_units_buf,
+            direction: Option::None,
+        }
+    }
+}
+
+impl<'tcx, 'sunit> VisitorMut for EncCall<'tcx, 'sunit> {
+    type Err = AnnotationError;
+
+    fn visit_decl(&mut self, decl: &mut DeclKind) -> Result<(), Self::Err> {
+        if let DeclKind::ProcDecl(decl_ref) = decl {
+            self.direction = Some(decl_ref.borrow().direction);
+            self.visit_proc(decl_ref)?;
+        }
+        Ok(())
+    }
+
+    fn visit_stmts(&mut self, stmts: &mut Vec<Stmt>) -> Result<(), Self::Err> {
+        // Check if the program consists of only one loop
+        let mut encoding: Option<(Rc<dyn Encoding>, Span)> = None;
+
+        let mut is_one_loop = true;
+        for s in &mut *stmts {
+            match &mut s.node {
+                StmtKind::Annotation(ident, _, _) => {
+                    if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
+                        self.tcx.get(*ident).unwrap().as_ref()
+                    {
+                        encoding = Some((anno_ref.clone(), s.span));
+                    }
+                }
+                StmtKind::Var(_) => {}
+                _ => {
+                    is_one_loop = false;
+                }
+            }
+        }
+        // If the annotated encoding only supports one loop programs throw an error
+        if let Some((enc, span)) = encoding {
+            if enc.is_one_loop() && !is_one_loop {
+                return Err(AnnotationError::OneLoopOnly(span, enc.name()));
+            }
+        }
+
+        for s in stmts {
+            self.visit_stmt(s)?;
+        }
+        Ok(())
+    }
+
+    fn visit_stmt(&mut self, s: &mut Stmt) -> Result<(), Self::Err> {
+        if let StmtKind::Annotation(ident, inputs, inner_stmt) = &mut s.node {
+            if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
+                self.tcx.get(*ident).unwrap().as_ref()
+            {
+                if let StmtKind::While(_, _) = inner_stmt.node {
+                } else {
+                    return Err(AnnotationError::NotOnWhile(s.span, *ident, s.clone()));
+                }
+
+                let (span, stmts, decls_opt) = anno_ref.transform(
+                    self.tcx,
+                    s.span,
+                    inputs,
+                    inner_stmt,
+                    self.direction
+                        .ok_or(AnnotationError::NotInProcedure(s.span, *ident))?,
+                )?;
+                s.span = span;
+                s.node = StmtKind::Block(stmts);
+                if let Some(decls) = decls_opt {
+                    let items: Vec<Item<SourceUnit>> = decls
+                        .into_iter()
+                        .map(|decl| SourceUnit::Decl(decl).wrap_item(&SourceFilePath::Generated))
+                        .collect();
+
+                    self.source_units_buf.extend(items)
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use pretty_assertions::assert_eq;
+
+    fn remove_whitespace(s: &mut String) {
+        s.retain(|c| !c.is_whitespace());
+    }
+
+    use crate::single_desugar_test;
+    use crate::verify_test;
+
+    #[test]
+    fn test_k_induction_transform() {
+        let mut test_string = String::from(
+            r#"
+            proc main() -> () 
+                pre ∞
+                post ∞
+            {
+                var x: UInt
+                {
+                    assert cast(EUReal, x)
+                    havoc x
+                    validate
+                    assume cast(EUReal, x)
+                    if (1 <= x) {
+                        x = (x - 1)
+                        assert cast(EUReal, x)
+                        assume cast(EUReal, 0)
+                    } else {
+                    }
+                }
+            }
+        "#,
+        );
+        let source = r#"
+            proc main() -> () {
+                var x: UInt
+                @k_induction(1, x)
+                while 1 <= x {
+                    x = x - 1
+                }
+            }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+    #[test]
+    fn test_bmc_transform() {
+        let mut test_string = String::from(
+            r#"
+            proc main() -> () 
+                pre ∞
+                post ∞
+            {
+                var x: UInt
+                {
+                    if (1 <= x) {
+                        x = (x - 1)
+                        assert cast(EUReal, 1)
+                        assume cast(EUReal, 0)
+                    } else {
+
+                    }
+                }
+            }
+        "#,
+        );
+        let source = r#"
+            proc main() -> () {
+                var x: UInt
+                @bmc(1, x)
+                while 1 <= x {
+                    x = x - 1
+                }
+            }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+
+    #[test]
+    fn test_omega_transform() {
+        let mut test_string = String::from(
+            r#"
+            proc main() -> () 
+                pre ∞
+                post ∞
+            {
+                var x: UInt
+                {
+                    cohavoc n
+                    assert [(n > x)]
+                    if ⊓ {
+                        validate
+                        assume ([(n > x)])[n -> 0]
+                        if (1 <= x) {
+                            x = (x - 1)
+                            assert cast(EUReal, 0)
+                            assume cast(EUReal, 0)
+                        } else {
+                
+                        }
+                    } else {
+                        havoc n
+                        validate
+                        assume ([(n > x)])[n -> (n + 1)]
+                        if (1 <= x) {
+                            x = (x - 1)
+                            assert [(n > x)]
+                            assume cast(EUReal, 0)
+                        } else {
+                
+                        }
+                    }
+                }
+            }
+        "#,
+        );
+        let source = r#"
+            proc main() -> () {
+                var x: UInt
+                @omega_inv(n,[n > x])
+                while 1 <= x {
+                    x = x - 1
+                }
+            }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+
+    #[test]
+    fn test_ost_transform() {
+        let mut test_string = String::from(
+            r#"
+            proc lt_infinity(a: Bool) -> () {
+                assert ?(((cast(EUReal, 2) * [a]) < ∞))
+            }
+            proc past(init_prob_choice: Bool, init_a: Bool, init_b: UInt, init_k: UInt) -> (
+                prob_choice: Bool, a: Bool, b: UInt, k: UInt
+            )
+                pre ((cast(EUReal, 2) * [a]))[a -> init_a]
+                post cast(EUReal, 0)
+            {
+                prob_choice = init_prob_choice
+                a = init_a
+                b = init_b
+                k = init_k
+                if a {
+                    prob_choice = flip(((cast(UReal, 1) / cast(UReal, 2))))
+                    if prob_choice { a = false } else { b = (b + 1) }
+                    k = (k + 1)
+                    assert (cast(EUReal, 2) * [a])
+                    assume cast(EUReal, 0)
+                } else {
+            
+                }
+            }
+            proc conditional_difference_bounded(
+                init_prob_choice: Bool, init_a: Bool, init_b: UInt, init_k: UInt
+            ) -> (prob_choice: Bool, a: Bool, b: UInt, k: UInt)
+                pre cast(EUReal, cast(UReal, 1))
+                post ite(
+                    (
+                        (((cast(EUReal, b) + [a]))[b -> init_b])[a -> init_a] <= (
+                            cast(EUReal, b) + [a]
+                        )
+                    ),
+                    (
+                        (cast(EUReal, b) + [a]) - (
+                            ((cast(EUReal, b) + [a]))[b -> init_b]
+                        )[a -> init_a]
+                    ),
+                    (
+                        (((cast(EUReal, b) + [a]))[b -> init_b])[a -> init_a] - (
+                            cast(EUReal, b) + [a]
+                        )
+                    )
+                )
+            {
+                prob_choice = init_prob_choice
+                a = init_a
+                b = init_b
+                k = init_k
+                prob_choice = flip(((cast(UReal, 1) / cast(UReal, 2))))
+                if prob_choice { a = false } else { b = (b + 1) }
+                k = (k + 1)
+            }
+            proc harmonize_I_f(a: Bool, b: UInt) -> () {
+                assert ?((! (a) → ((cast(EUReal, b) + [a]) == cast(EUReal, b))))
+            }
+            proc loopiter_lt_infty(
+                init_prob_choice: Bool, init_a: Bool, init_b: UInt, init_k: UInt
+            ) -> (prob_choice: Bool, a: Bool, b: UInt, k: UInt)
+                pre cast(EUReal, 0)
+                post cast(EUReal, b)
+            {
+                prob_choice = init_prob_choice
+                a = init_a
+                b = init_b
+                k = init_k
+                validate
+                assume ∞
+                if a {
+                    prob_choice = flip(((cast(UReal, 1) / cast(UReal, 2))))
+                    if prob_choice { a = false } else { b = (b + 1) }
+                    k = (k + 1)
+                    assert (cast(EUReal, b) + [a])
+                    assume cast(EUReal, 0)
+                } else {
+            
+                }
+            }
+            proc lower_bound(
+                init_prob_choice: Bool, init_a: Bool, init_b: UInt, init_k: UInt
+            ) -> (prob_choice: Bool, a: Bool, b: UInt, k: UInt)
+                pre (((cast(EUReal, b) + [a]))[b -> init_b])[a -> init_a]
+                post cast(EUReal, b)
+            {
+                prob_choice = init_prob_choice
+                a = init_a
+                b = init_b
+                k = init_k
+                if a {
+                    prob_choice = flip(((cast(UReal, 1) / cast(UReal, 2))))
+                    if prob_choice { a = false } else { b = (b + 1) }
+                    k = (k + 1)
+                    assert (cast(EUReal, b) + [a])
+                    assume cast(EUReal, 0)
+                } else {
+            
+                }
+            }
+            proc optional_stopping(init_b: UInt, init_a: Bool) -> (b: UInt, a: Bool)
+                pre (cast(EUReal, init_b) + [init_a])
+                post cast(EUReal, b)
+            {
+                var prob_choice: Bool
+                var k: UInt
+                b = init_b
+                a = init_a
+                { prob_choice, a, b, k = lower_bound(prob_choice, a, b, k) }
+            }
+        "#,
+        );
+        let source = r#"
+        proc optional_stopping(init_b: UInt, init_a: Bool) -> (b: UInt, a: Bool)
+            pre init_b + [init_a]
+            post b
+        {
+            var prob_choice: Bool
+            var k: UInt
+
+            b = init_b
+            a = init_a
+
+            @ost(b + [a], 2 * [a], 1, b)
+            while a {
+                prob_choice = flip((1/2))
+                if prob_choice {
+                    a = false
+                } else {
+                   b = b + 1
+                }
+                k = k + 1
+            }
+        }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+
+    #[test]
+    fn test_past_transform() {
+        let mut test_string = String::from(
+            r#"
+            proc condition_1(x: UInt) -> () {
+                assert ?((([! ((1 <= x))] * cast(EUReal, (x + 1))) <= 10/10))
+            }
+            proc condition_2(x: UInt) -> () {
+                assert (
+                    ([(1 <= x)] * 10/10) <= (
+                        ([(1 <= x)] * cast(EUReal, (x + 1))) + [! ((1 <= x))]
+                    )
+                )
+            }
+            proc past(init_x: UInt) -> (x: UInt)
+                pre ([(1 <= x)] * ((cast(EUReal, (x + 1)))[x -> init_x] - 5/10))
+                post cast(EUReal, 0)
+            {
+                x = init_x
+                if (1 <= x) {
+                    x = (x - 1)
+                    assert cast(EUReal, (x + 1))
+                    assume cast(EUReal, 0)
+                } else {
+            
+                }
+            }
+            proc main() -> ()
+                pre ∞
+                post ∞
+            {
+                var x: UInt
+                {  }
+            }
+        "#,
+        );
+        let source = r#"
+            proc main() -> () {
+                var x: UInt
+                @past(x+1, 0.5, 1.0)
+                while 1 <= x {
+                    x = x - 1
+                }
+            }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+
+    #[test]
+    fn test_ast_transform() {
+        let mut test_string = String::from(
+            r#"
+        proc prob_antitone(a: UReal, b: UReal) -> ()
+            pre ?((a <= b))
+            post ?(((5/10)[v -> a] >= (5/10)[v -> b]))
+        {
+            
+        }
+        proc decrease_antitone(a: UReal, b: UReal) -> ()
+            pre ?((a <= b))
+            post ?(((cast(UReal, v))[v -> a] >= (cast(UReal, v))[v -> b]))
+        {
+            
+        }
+        proc I_wp_subinvariant(init_x: UInt) -> (x: UInt)
+            pre ([true])[x -> init_x]
+            post [true]
+        {
+            x = init_x
+            if (1 <= x) { x = (x - 1) } else {  }
+        }
+        proc termination_condition(x: UInt) -> () {
+            assert ?((! ((1 <= x)) == (cast(EUReal, x) == cast(EUReal, 0))))
+        }
+        proc V_wp_superinvariant(init_x: UInt) -> (x: UInt)
+            pre (cast(EUReal, x))[x -> init_x]
+            post cast(EUReal, x)
+        {
+            x = init_x
+            if (1 <= x) { x = (x - 1) } else {  }
+        }
+        proc progress_condition(init_x: UInt) -> (x: UInt)
+            pre (([true] * ([(1 <= x)] * (5/10)[v -> cast(EUReal, x)])))[x -> init_x]
+            post [(
+                cast(EUReal, x) <= (
+                    (cast(EUReal, x))[x -> init_x] - (cast(UReal, v))[v -> (
+                        cast(EUReal, x)
+                    )[x -> init_x]]
+                )
+            )]
+        {
+            x = init_x
+            x = (x - 1)
+        }
+        proc main() -> ()
+            pre ∞
+            post ∞
+        {
+            var x: UInt
+            {  }
+        }
+        "#,
+        );
+        let source = r#"
+            proc main() -> () {
+                var x: UInt
+                @ast(true, x, v, 0.5, v)
+                while 1 <= x {
+                    x = x - 1
+                }
+            }
+        "#;
+        let mut res = single_desugar_test(source).unwrap();
+        remove_whitespace(&mut test_string);
+        remove_whitespace(&mut res);
+        assert_eq!(test_string, res);
+    }
+
+    #[test]
+    fn test_past_not_on_while() {
+        let source = r#"
+    proc main() -> () {
+        var x: UInt
+        @past(x+1, 0.5, 1.0)
+        x= x+1;
+    }
+"#;
+
+        let err = verify_test(&source).0.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Error: The annotation `past` is not on a while statement"
+        );
+    }
+
+    #[test]
+    fn test_invariant_not_on_while() {
+        let source = r#"
+        proc main2() -> () {
+            var x: UInt
+            @invariant(x)
+            x = x + 1
+        }
+        "#;
+        let err = verify_test(&source).0.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Error: The annotation `invariant` is not on a while statement"
+        );
+    }
+}

--- a/src/proof_rules/induction.rs
+++ b/src/proof_rules/induction.rs
@@ -1,0 +1,329 @@
+use std::fmt;
+
+use crate::{
+    ast::{
+        util::ModifiedVariableCollector, visit::VisitorMut, DeclKind, Direction, Expr, ExprBuilder,
+        Files, Ident, SourceFilePath, Span, Spanned, Stmt, Symbol, TyKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+
+use super::util::*;
+
+/// Syntactic sugar encoding for K-Induction encodings of type k=1
+pub struct InvariantAnnotation(AnnotationInfo);
+
+impl InvariantAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files
+            .add(SourceFilePath::Builtin, "invariant".to_string())
+            .id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("invariant"), file);
+
+        let invariant_param = intrinsic_param(file, "inv", TyKind::SpecTy, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![invariant_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        InvariantAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for InvariantAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InvariantAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for InvariantAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [invariant] = mut_one_arg(args);
+        resolve.visit_expr(invariant)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let mut visitor = ModifiedVariableCollector::new();
+        visitor.visit_stmt(&mut inner_stmt.clone()).unwrap();
+        let havoc_vars = visitor.modified_variables.into_iter().collect();
+
+        let [invariant] = one_arg(args);
+
+        let mut buf = vec![];
+
+        // Construct the specification of the k-induction encoding
+        buf.extend(encode_spec(
+            annotation_span,
+            invariant,
+            invariant,
+            havoc_vars,
+            direction,
+        ));
+
+        // Extend the loop k-1 times with the opposite direction
+        let next_iter = encode_extend(
+            annotation_span,
+            inner_stmt,
+            0,
+            invariant,
+            direction.toggle(),
+            false,
+            hey_const(annotation_span, invariant, tcx),
+        );
+
+        // Encode the last iteration in the normal direction
+        buf.push(encode_iter(annotation_span, inner_stmt, next_iter).unwrap());
+
+        Ok((annotation_span, buf, None))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}
+
+pub struct KIndAnnotation(AnnotationInfo);
+
+impl KIndAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files
+            .add(SourceFilePath::Builtin, "k_induction".to_string())
+            .id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("k_induction"), file);
+
+        let k_param = intrinsic_param(file, "k", TyKind::UInt, true);
+        let invariant_param = intrinsic_param(file, "inv", TyKind::SpecTy, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![k_param, invariant_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        KIndAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for KIndAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KIndAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for KIndAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [k, invariant] = mut_two_args(args);
+        resolve.visit_expr(k)?;
+        resolve.visit_expr(invariant)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let mut visitor = ModifiedVariableCollector::new();
+        visitor.visit_stmt(&mut inner_stmt.clone()).unwrap();
+        let havoc_vars = visitor.modified_variables.into_iter().collect();
+
+        let [k, invariant] = two_args(args);
+
+        let k: u128 = lit_u128(k);
+
+        let mut buf = vec![];
+
+        // Construct the specification of the k-induction encoding
+        buf.extend(encode_spec(
+            annotation_span,
+            invariant,
+            invariant,
+            havoc_vars,
+            direction,
+        ));
+
+        // Extend the loop k-1 times with the opposite direction
+        let next_iter = encode_extend(
+            annotation_span,
+            inner_stmt,
+            k - 1,
+            invariant,
+            direction.toggle(),
+            false,
+            hey_const(annotation_span, invariant, tcx),
+        );
+
+        // Encode the last iteration in the normal direction
+        buf.push(encode_iter(annotation_span, inner_stmt, next_iter).unwrap());
+
+        Ok((annotation_span, buf, None))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}
+
+pub struct BMCAnnotation(AnnotationInfo);
+
+impl BMCAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files.add(SourceFilePath::Builtin, "bmc".to_string()).id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("bmc"), file);
+
+        let k_param = intrinsic_param(file, "k", TyKind::UInt, true);
+        let invariant_param = intrinsic_param(file, "inv", TyKind::SpecTy, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![k_param, invariant_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        BMCAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for BMCAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BMCAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for BMCAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [k, invariant] = mut_two_args(args);
+        resolve.visit_expr(k)?;
+        resolve.visit_expr(invariant)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let [k, invariant] = two_args(args);
+
+        let k: u128 = lit_u128(k);
+
+        let builder = ExprBuilder::new(annotation_span);
+
+        // Innermost constant expression is 0 for upper bounds and 1 for lower bounds
+        let const_prog = match direction {
+            Direction::Down => hey_const(
+                annotation_span,
+                &builder.cast(tcx.spec_ty().clone(), builder.uint(1)),
+                tcx,
+            ),
+            Direction::Up => hey_const(
+                annotation_span,
+                &builder.cast(tcx.spec_ty().clone(), builder.uint(0)),
+                tcx,
+            ),
+        };
+
+        // Extend the loop k times without asserts (unlike k-induction) because bmc flag is set
+        let buf = encode_extend(
+            annotation_span,
+            inner_stmt,
+            k,
+            invariant,
+            direction,
+            true,
+            const_prog,
+        );
+
+        Ok((annotation_span, buf, None))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}

--- a/src/proof_rules/mciver_ast.rs
+++ b/src/proof_rules/mciver_ast.rs
@@ -1,0 +1,416 @@
+use std::fmt;
+
+use indexmap::IndexSet;
+
+use crate::{
+    ast::{
+        util::ModifiedVariableCollector, visit::VisitorMut, BinOpKind, DeclKind, DeclRef,
+        Direction, Expr, ExprBuilder, ExprKind, Files, Ident, ProcSpec, SourceFilePath, Span,
+        Spanned, Stmt, StmtKind, Symbol, TyKind, UnOpKind, VarDecl, VarKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+
+use super::util::*;
+
+pub struct ASTAnnotation(AnnotationInfo);
+
+impl ASTAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files.add(SourceFilePath::Builtin, "ast".to_string()).id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("ast"), file);
+
+        let invariant_param = intrinsic_param(file, "invariant", TyKind::Bool, false);
+        let variant_param = intrinsic_param(file, "variant", TyKind::SpecTy, false);
+        let free_var_param = intrinsic_param(file, "free_variable", TyKind::UInt, false);
+        let prob_param = intrinsic_param(file, "prob", TyKind::UReal, false);
+        let decr_param = intrinsic_param(file, "decrease", TyKind::UReal, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(
+                vec![
+                    invariant_param,
+                    variant_param,
+                    free_var_param,
+                    prob_param,
+                    decr_param,
+                ],
+                file,
+            ),
+            span: Span::dummy_file_span(file),
+        };
+
+        ASTAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for ASTAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ASTAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for ASTAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn is_one_loop(&self) -> bool {
+        true
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [invariant, variant, free_var, prob, decrease] = mut_five_args(args);
+        resolve.visit_expr(invariant)?;
+        resolve.visit_expr(variant)?;
+
+        if let ExprKind::Var(var_ref) = &free_var.kind {
+            let var_decl = VarDecl {
+                name: *var_ref,
+                ty: TyKind::UInt,
+                kind: VarKind::Mut,
+                init: None,
+                span: call_span,
+            };
+            // Declare the free variable to be used in the omega invariant
+            resolve.declare(DeclKind::VarDecl(DeclRef::new(var_decl)))?;
+        }
+
+        resolve.visit_expr(prob)?;
+        resolve.visit_expr(decrease)
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        _direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let [invariant, variant, free_var, prob, decrease] = five_args(args);
+        let builder = ExprBuilder::new(annotation_span);
+
+        // Unpack the loop guard and body from the [`Stmt`]
+        let (loop_guard, loop_body) = if let StmtKind::While(guard, body) = &inner_stmt.node {
+            (guard, body)
+        } else {
+            return Err(AnnotationError::NotOnWhile(
+                annotation_span,
+                self.name(),
+                inner_stmt.clone(),
+            ));
+        };
+
+        let free_var = if let ExprKind::Var(var_ref) = &free_var.kind {
+            *var_ref
+        } else {
+            return Err(AnnotationError::WrongArgument(
+                annotation_span,
+                free_var.clone(),
+                String::from("This argument must be a single variable expression."),
+            ));
+        };
+
+        // Collect modified variables (exclude the variables that are declared in the loop)
+        let mut visitor = ModifiedVariableCollector::new();
+        visitor.visit_stmt(&mut inner_stmt.clone()).unwrap();
+        let modified_vars: Vec<Ident> = (&visitor.modified_variables - &visitor.declared_variables)
+            .into_iter()
+            .collect();
+
+        let modified_or_used: IndexSet<Ident> = visitor
+            .modified_variables
+            .union(&visitor.used_variables)
+            .into_iter()
+            .cloned()
+            .collect();
+
+        // Get the "init_{}" versions of the variable identifiers and declare them
+        let init_idents = get_init_idents(tcx, annotation_span, &modified_vars);
+
+        // Variables that are used but not modified or declared in the loop (These won't be transformed into an init version)
+        let only_used_idents: Vec<Ident> = (&visitor.used_variables
+            - &visitor
+                .declared_variables
+                .union(&visitor.modified_variables)
+                .into_iter()
+                .cloned()
+                .collect::<IndexSet<Ident>>())
+            .into_iter()
+            .collect();
+
+        // init version of variables and only-used variables without "init_"
+        let mut input_init_vars = init_idents.clone();
+        input_init_vars.extend(only_used_idents);
+
+        // Transform the [`Ident`]s into [`Expr`]s for assignments.
+        let init_exprs = init_idents
+            .iter()
+            .map(|ident| ident_to_expr(tcx, annotation_span, *ident))
+            .collect();
+
+        let init_assigns = multiple_assign(annotation_span, modified_vars.clone(), init_exprs);
+
+        // That is modified variables AND variables used in an expression (exclude the variables that are declared in the loop)
+        // ((Modified ∪ Used) - Declared)
+        // This is used in procs that do not modify any variables in their body
+        let input_vars: Vec<Ident> = (&modified_or_used - &visitor.declared_variables)
+            .into_iter()
+            .collect();
+
+        // Replace all variables with the init versions in the past-invariant
+        let init_variant = to_init_expr(tcx, annotation_span, variant, &modified_vars);
+
+        let a_ident = new_ident_with_name(tcx, &TyKind::UReal, annotation_span, "a");
+        let a_expr = ident_to_expr(tcx, annotation_span, a_ident);
+
+        let b_ident = new_ident_with_name(tcx, &TyKind::UReal, annotation_span, "b");
+        let b_expr = ident_to_expr(tcx, annotation_span, b_ident);
+
+        let cond1_2_pre = builder.unary(
+            UnOpKind::Embed,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Le,
+                Some(TyKind::Bool),
+                a_expr.clone(),
+                b_expr.clone(),
+            ),
+        );
+
+        let cond1_post = builder.unary(
+            UnOpKind::Embed,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Ge,
+                Some(TyKind::Bool),
+                builder.subst(prob.clone(), [(free_var, a_expr.clone())]),
+                builder.subst(prob.clone(), [(free_var, b_expr.clone())]),
+            ),
+        );
+
+        let cond2_post = builder.unary(
+            UnOpKind::Embed,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Ge,
+                Some(TyKind::Bool),
+                builder.subst(decrease.clone(), [(free_var, a_expr)]),
+                builder.subst(decrease.clone(), [(free_var, b_expr)]),
+            ),
+        );
+
+        // prob antitone
+        let cond1_proc = generate_proc(
+            annotation_span,
+            "prob_antitone",
+            params_from_idents(vec![a_ident, b_ident], tcx),
+            vec![],
+            vec![
+                ProcSpec::Requires(cond1_2_pre.clone()),
+                ProcSpec::Ensures(cond1_post),
+            ],
+            vec![],
+            Direction::Down,
+            tcx,
+        );
+
+        // decrease antitone
+        let cond2_proc = generate_proc(
+            annotation_span,
+            "decrease_antitone",
+            params_from_idents(vec![a_ident, b_ident], tcx),
+            vec![],
+            vec![
+                ProcSpec::Requires(cond1_2_pre),
+                ProcSpec::Ensures(cond2_post),
+            ],
+            vec![],
+            Direction::Down,
+            tcx,
+        );
+
+        let cond3_expr = builder.unary(UnOpKind::Iverson, Some(TyKind::EUReal), invariant.clone());
+
+        let mut cond3_body = init_assigns.clone();
+        cond3_body.push(
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                // hey_const(annotation_span, &cond3_expr, tcx),
+                vec![],
+            )
+            .unwrap(),
+        );
+
+        // [I] <= Phi_{[I]}([I])
+        let cond3_proc = generate_proc(
+            annotation_span,
+            "I_wp_subinvariant",
+            params_from_idents(input_init_vars.clone(), tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(to_init_expr(
+                    tcx,
+                    annotation_span,
+                    &cond3_expr,
+                    &modified_vars,
+                )),
+                ProcSpec::Ensures(cond3_expr.clone()),
+            ],
+            cond3_body,
+            Direction::Down,
+            tcx,
+        );
+
+        // ?((~loop_guard) == (variant = 0))
+        let cond4_expr = builder.unary(
+            UnOpKind::Embed,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Eq,
+                Some(TyKind::Bool),
+                builder.unary(UnOpKind::Not, Some(TyKind::Bool), loop_guard.clone()),
+                builder.binary(
+                    BinOpKind::Eq,
+                    Some(TyKind::Bool),
+                    variant.clone(),
+                    builder.cast(TyKind::EUReal, builder.uint(0)),
+                ),
+            ),
+        );
+        // !G iff V = 0
+        let cond4_proc = generate_proc(
+            annotation_span,
+            "termination_condition",
+            params_from_idents(input_vars, tcx),
+            vec![],
+            vec![],
+            vec![Spanned::new(
+                annotation_span,
+                StmtKind::Assert(Direction::Down, cond4_expr),
+            )],
+            Direction::Down,
+            tcx,
+        );
+        let mut cond5_body = init_assigns.clone();
+        cond5_body.push(
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                // hey_const(annotation_span, &variant, tcx),
+                vec![],
+            )
+            .unwrap(),
+        );
+
+        // Phi_{V}(V) <= V
+        let cond5_proc = generate_proc(
+            annotation_span,
+            "V_wp_superinvariant",
+            params_from_idents(input_init_vars.clone(), tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(to_init_expr(tcx, annotation_span, variant, &modified_vars)),
+                ProcSpec::Ensures(variant.clone()),
+            ],
+            cond5_body,
+            Direction::Up,
+            tcx,
+        );
+
+        let cond6_pre = builder.binary(
+            BinOpKind::Mul,
+            Some(TyKind::EUReal),
+            builder.unary(
+                UnOpKind::Iverson,
+                Some(TyKind::EUReal),
+                invariant.to_owned(),
+            ),
+            builder.binary(
+                BinOpKind::Mul,
+                Some(TyKind::EUReal),
+                builder.unary(
+                    UnOpKind::Iverson,
+                    Some(TyKind::EUReal),
+                    loop_guard.to_owned(),
+                ),
+                builder.subst(prob.clone(), [(free_var, variant.clone())]),
+            ),
+        );
+
+        let cond6_post = builder.unary(
+            UnOpKind::Iverson,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Le,
+                Some(TyKind::Bool),
+                variant.clone(),
+                builder.binary(
+                    BinOpKind::Sub,
+                    Some(TyKind::EUReal),
+                    init_variant.clone(),
+                    builder.subst(decrease.clone(), [(free_var, init_variant)]),
+                ),
+            ),
+        );
+
+        let mut cond6_body = init_assigns;
+        cond6_body.extend(loop_body.clone());
+
+        //[I] * [G] * (p o V) <= \\s. wp[P]([V < V(s) - d(V(s))])(s)
+        let cond6_proc = generate_proc(
+            annotation_span,
+            "progress_condition",
+            params_from_idents(input_init_vars, tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(to_init_expr(
+                    tcx,
+                    annotation_span,
+                    &cond6_pre,
+                    &modified_vars,
+                )),
+                ProcSpec::Ensures(cond6_post),
+            ],
+            cond6_body,
+            Direction::Down,
+            tcx,
+        );
+
+        Ok((
+            annotation_span,
+            vec![],
+            Some(vec![
+                cond1_proc, cond2_proc, cond3_proc, cond4_proc, cond5_proc, cond6_proc,
+            ]),
+        ))
+    }
+}

--- a/src/proof_rules/mod.rs
+++ b/src/proof_rules/mod.rs
@@ -1,0 +1,86 @@
+pub mod enc_call;
+mod induction;
+use induction::*;
+mod mciver_ast;
+use mciver_ast::*;
+mod omega;
+use omega::*;
+mod ost;
+use ost::*;
+mod past;
+use past::*;
+mod util;
+
+pub use enc_call::EncCall;
+
+use std::{fmt, rc::Rc};
+
+use crate::{
+    ast::{DeclKind, Direction, Expr, Files, Ident, Span, Stmt},
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{AnnotationError, AnnotationKind},
+    tyctx::TyCtx,
+};
+
+pub trait Encoding: fmt::Debug {
+    fn name(&self) -> Ident;
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError>;
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError>;
+
+    fn transform(
+        &self,
+        tyctx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError>;
+
+    fn is_one_loop(&self) -> bool;
+}
+
+/// Initialize all intrinsic annotations by declaring them
+pub fn init_encodings(files: &mut Files, tcx: &mut TyCtx) {
+    let invariant = AnnotationKind::Encoding(Rc::new(InvariantAnnotation::new(tcx, files)));
+    tcx.add_global(invariant.name());
+    tcx.declare(DeclKind::AnnotationDecl(invariant));
+
+    let k_ind = AnnotationKind::Encoding(Rc::new(KIndAnnotation::new(tcx, files)));
+    tcx.add_global(k_ind.name());
+    tcx.declare(DeclKind::AnnotationDecl(k_ind));
+
+    let bmc = AnnotationKind::Encoding(Rc::new(BMCAnnotation::new(tcx, files)));
+    tcx.add_global(bmc.name());
+    tcx.declare(DeclKind::AnnotationDecl(bmc));
+
+    let omega_inv = AnnotationKind::Encoding(Rc::new(OmegaInvAnnotation::new(tcx, files)));
+    tcx.add_global(omega_inv.name());
+    tcx.declare(DeclKind::AnnotationDecl(omega_inv));
+
+    let ost = AnnotationKind::Encoding(Rc::new(OSTAnnotation::new(tcx, files)));
+    tcx.add_global(ost.name());
+    tcx.declare(DeclKind::AnnotationDecl(ost));
+
+    let past = AnnotationKind::Encoding(Rc::new(PASTAnnotation::new(tcx, files)));
+    tcx.add_global(past.name());
+    tcx.declare(DeclKind::AnnotationDecl(past));
+
+    let ast = AnnotationKind::Encoding(Rc::new(ASTAnnotation::new(tcx, files)));
+    tcx.add_global(ast.name());
+    tcx.declare(DeclKind::AnnotationDecl(ast));
+}

--- a/src/proof_rules/mod.rs
+++ b/src/proof_rules/mod.rs
@@ -1,6 +1,9 @@
-pub mod enc_call;
+//! This module provides annotations that encode proof rules and their desugaring transformations.
+
 mod induction;
 use induction::*;
+mod unroll;
+use unroll::*;
 mod mciver_ast;
 use mciver_ast::*;
 mod omega;
@@ -11,12 +14,17 @@ mod past;
 use past::*;
 mod util;
 
-pub use enc_call::EncCall;
+#[cfg(test)]
+mod tests;
 
 use std::{fmt, rc::Rc};
 
 use crate::{
-    ast::{DeclKind, Direction, Expr, Files, Ident, Span, Stmt},
+    ast::{
+        visit::VisitorMut, DeclKind, Direction, Expr, Files, Ident, Param, ProcSpec,
+        SourceFilePath, Span, Stmt, StmtKind,
+    },
+    driver::{Item, SourceUnit},
     front::{
         resolve::{Resolve, ResolveError},
         tycheck::{Tycheck, TycheckError},
@@ -24,6 +32,22 @@ use crate::{
     intrinsic::annotations::{AnnotationError, AnnotationKind},
     tyctx::TyCtx,
 };
+
+pub struct ProcInfo {
+    name: String,
+    inputs: Vec<Param>,
+    outputs: Vec<Param>,
+    spec: Vec<ProcSpec>,
+    body: Vec<Stmt>,
+    direction: Direction,
+}
+
+/// The result of transforming an annotation call, it can contain generated statements and declarations
+pub struct EncodingGenerated {
+    span: Span,
+    stmts: Vec<Stmt>,
+    decls: Option<Vec<DeclKind>>,
+}
 
 pub trait Encoding: fmt::Debug {
     fn name(&self) -> Ident;
@@ -49,7 +73,7 @@ pub trait Encoding: fmt::Debug {
         args: &[Expr],
         inner_stmt: &Stmt,
         direction: Direction,
-    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError>;
+    ) -> Result<EncodingGenerated, AnnotationError>;
 
     fn is_one_loop(&self) -> bool;
 }
@@ -64,7 +88,7 @@ pub fn init_encodings(files: &mut Files, tcx: &mut TyCtx) {
     tcx.add_global(k_ind.name());
     tcx.declare(DeclKind::AnnotationDecl(k_ind));
 
-    let bmc = AnnotationKind::Encoding(Rc::new(BMCAnnotation::new(tcx, files)));
+    let bmc = AnnotationKind::Encoding(Rc::new(UnrollAnnotation::new(tcx, files)));
     tcx.add_global(bmc.name());
     tcx.declare(DeclKind::AnnotationDecl(bmc));
 
@@ -83,4 +107,176 @@ pub fn init_encodings(files: &mut Files, tcx: &mut TyCtx) {
     let ast = AnnotationKind::Encoding(Rc::new(ASTAnnotation::new(tcx, files)));
     tcx.add_global(ast.name());
     tcx.declare(DeclKind::AnnotationDecl(ast));
+}
+
+/// Walks the AST and transforms annotations into their desugared form
+pub struct EncCall<'tcx, 'sunit> {
+    tcx: &'tcx mut TyCtx,
+    source_units_buf: &'sunit mut Vec<Item<SourceUnit>>,
+    direction: Option<Direction>,
+}
+
+impl<'tcx, 'sunit> EncCall<'tcx, 'sunit> {
+    pub fn new(tcx: &'tcx mut TyCtx, source_units_buf: &'sunit mut Vec<Item<SourceUnit>>) -> Self {
+        EncCall {
+            tcx,
+            source_units_buf,
+            direction: Option::None,
+        }
+    }
+}
+
+impl<'tcx, 'sunit> VisitorMut for EncCall<'tcx, 'sunit> {
+    type Err = AnnotationError;
+
+    fn visit_decl(&mut self, decl: &mut DeclKind) -> Result<(), Self::Err> {
+        if let DeclKind::ProcDecl(decl_ref) = decl {
+            self.direction = Some(decl_ref.borrow().direction);
+            self.visit_proc(decl_ref)?;
+        }
+        Ok(())
+    }
+
+    fn visit_stmts(&mut self, stmts: &mut Vec<Stmt>) -> Result<(), Self::Err> {
+        // Check if the program consists of only one loop
+        let mut encoding: Option<(Rc<dyn Encoding>, Span)> = None;
+
+        let mut is_one_loop = true;
+        for s in &mut *stmts {
+            match &mut s.node {
+                StmtKind::Annotation(ident, _, _) => {
+                    if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
+                        self.tcx.get(*ident).unwrap().as_ref()
+                    {
+                        encoding = Some((anno_ref.clone(), s.span));
+                    }
+                }
+                StmtKind::Var(_) => {}
+                _ => {
+                    is_one_loop = false;
+                }
+            }
+        }
+        // If the annotated encoding only supports one loop programs throw an error
+        if let Some((enc, span)) = encoding {
+            if enc.is_one_loop() && !is_one_loop {
+                return Err(AnnotationError::OneLoopOnly(span, enc.name()));
+            }
+        }
+
+        for s in stmts {
+            self.visit_stmt(s)?;
+        }
+        Ok(())
+    }
+
+    fn visit_stmt(&mut self, s: &mut Stmt) -> Result<(), Self::Err> {
+        walk_stmt(self, s)?;
+        if let StmtKind::Annotation(ident, inputs, inner_stmt) = &mut s.node {
+            if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
+                self.tcx.get(*ident).unwrap().as_ref()
+            {
+                if let StmtKind::While(_, _) = inner_stmt.node {
+                } else {
+                    return Err(AnnotationError::NotOnWhile(s.span, *ident, s.clone()));
+                }
+
+                let mut enc_gen = anno_ref.transform(
+                    self.tcx,
+                    s.span,
+                    inputs,
+                    inner_stmt,
+                    self.direction
+                        .ok_or(AnnotationError::NotInProcedure(s.span, *ident))?,
+                )?;
+
+                let stmts = &mut enc_gen.stmts;
+                let span = enc_gen.span;
+                let decls_opt = &mut enc_gen.decls;
+
+                // Visit generated statements
+                self.visit_stmts(stmts)?;
+                s.span = span;
+                s.node = StmtKind::Block(stmts.to_vec());
+
+                if let Some(ref mut decls) = decls_opt {
+                    // Visit generated declarations
+                    self.visit_decls(decls)?;
+
+                    // Wrap generated declarations in items
+                    let items: Vec<Item<SourceUnit>> = decls
+                        .iter_mut()
+                        .map(|decl| {
+                            SourceUnit::Decl(decl.to_owned()).wrap_item(&SourceFilePath::Generated)
+                        })
+                        .collect();
+
+                    self.source_units_buf.extend(items)
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn walk_stmt<V: VisitorMut>(visitor: &mut V, s: &mut Stmt) -> Result<(), V::Err> {
+    match &mut s.node {
+        StmtKind::Block(ref mut block) => {
+            visitor.visit_stmts(block)?;
+        }
+        StmtKind::Var(decl_ref) => {
+            visitor.visit_var_decl(decl_ref)?;
+        }
+        StmtKind::Assign(ref mut lhses, ref mut rhs) => {
+            for lhs in lhses {
+                visitor.visit_ident(lhs)?;
+            }
+            visitor.visit_expr(rhs)?;
+        }
+        StmtKind::Havoc(_dir, ref mut idents) => {
+            for ident in idents {
+                visitor.visit_ident(ident)?;
+            }
+        }
+        StmtKind::Assert(_dir, ref mut expr) => {
+            visitor.visit_expr(expr)?;
+        }
+        StmtKind::Assume(_dir, ref mut expr) => {
+            visitor.visit_expr(expr)?;
+        }
+        StmtKind::Compare(_dir, ref mut expr) => {
+            visitor.visit_expr(expr)?;
+        }
+        StmtKind::Negate(_dir) => {}
+        StmtKind::Validate(_dir) => {}
+        StmtKind::Tick(ref mut expr) => {
+            visitor.visit_expr(expr)?;
+        }
+        StmtKind::Demonic(ref mut block1, ref mut block2) => {
+            visitor.visit_stmts(block1)?;
+            visitor.visit_stmts(block2)?;
+        }
+        StmtKind::Angelic(ref mut block1, ref mut block2) => {
+            visitor.visit_stmts(block1)?;
+            visitor.visit_stmts(block2)?;
+        }
+        StmtKind::If(ref mut cond, ref mut block1, ref mut block2) => {
+            visitor.visit_expr(cond)?;
+            visitor.visit_stmts(block1)?;
+            visitor.visit_stmts(block2)?;
+        }
+        StmtKind::While(ref mut cond, ref mut block) => {
+            visitor.visit_expr(cond)?;
+            visitor.visit_stmts(block)?;
+        }
+        StmtKind::Annotation(ref mut ident, ref mut args, ref mut stmt) => {
+            visitor.visit_ident(ident)?;
+            visitor.visit_exprs(args)?;
+            visitor.visit_stmt(stmt)?;
+        }
+        StmtKind::Label(ref mut ident) => {
+            visitor.visit_ident(ident)?;
+        }
+    }
+    Ok(())
 }

--- a/src/proof_rules/omega.rs
+++ b/src/proof_rules/omega.rs
@@ -1,0 +1,192 @@
+use std::fmt;
+
+use crate::{
+    ast::{
+        visit::VisitorMut, BinOpKind, DeclKind, DeclRef, Direction, Expr, ExprBuilder, ExprKind,
+        Files, Ident, SourceFilePath, Span, Spanned, Stmt, StmtKind, Symbol, TyKind, VarDecl,
+        VarKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+
+use super::util::*;
+
+pub struct OmegaInvAnnotation(AnnotationInfo);
+
+impl OmegaInvAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files
+            .add(SourceFilePath::Builtin, "omega_inv".to_string())
+            .id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("omega_inv"), file);
+
+        let omega_inv_param = intrinsic_param(file, "omega_inv", TyKind::EUReal, false);
+        let free_var_param = intrinsic_param(file, "free_variable", TyKind::UInt, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![free_var_param, omega_inv_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        OmegaInvAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for OmegaInvAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OmegaInvAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for OmegaInvAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [free_var, omega_inv] = mut_two_args(args);
+        if let ExprKind::Var(var_ref) = &free_var.kind {
+            let var_decl = VarDecl {
+                name: *var_ref,
+                ty: TyKind::UInt,
+                kind: VarKind::Mut,
+                init: None,
+                span: call_span,
+            };
+            // Declare the free variable to be used in the omega invariant
+            resolve.declare(DeclKind::VarDecl(DeclRef::new(var_decl)))?;
+        }
+        resolve.visit_expr(omega_inv)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let [free_var, omega_inv] = two_args(args);
+
+        let omega_var = if let ExprKind::Var(var_ref) = &free_var.kind {
+            *var_ref
+        } else {
+            return Err(AnnotationError::WrongArgument(
+                annotation_span,
+                free_var.clone(),
+                String::from("This argument must be a single variable expression."),
+            ));
+        };
+
+        let builder = ExprBuilder::new(annotation_span);
+
+        // Construct n+1 expression to substitute n with n+1, in order to construct I_{n+1} later
+        let omega_var_plus_1 = builder.binary(
+            BinOpKind::Add,
+            Some(TyKind::UInt),
+            builder.var(omega_var, tcx),
+            builder.uint(1),
+        );
+
+        // Construct necessary expressions for the conditions
+        // I_{n+1}
+        let next_omega_inv = builder.subst(omega_inv.clone(), [(omega_var, omega_var_plus_1)]);
+        // I_{0}
+        let null_omega_inv = builder.subst(omega_inv.clone(), [(omega_var, builder.uint(0))]);
+
+        // Phi_x(I_n)
+        let iter = encode_iter(
+            annotation_span,
+            inner_stmt,
+            hey_const(annotation_span, omega_inv, tcx),
+        )
+        .unwrap();
+
+        //Phi_x(0)
+        let null_iter = encode_iter(
+            annotation_span,
+            inner_stmt,
+            hey_const(
+                annotation_span,
+                &builder.cast(tcx.spec_ty().clone(), builder.uint(0)),
+                tcx,
+            ),
+        )
+        .unwrap();
+
+        // I_0 <= Phi_{post}(0)
+        let cond1 = vec![
+            Spanned::new(annotation_span, StmtKind::Validate(direction)),
+            Spanned::new(annotation_span, StmtKind::Assume(direction, null_omega_inv)),
+            null_iter,
+        ];
+
+        // for all n. I_{n+1} <= Phi_{post}(I_n)
+        let cond2 = vec![
+            Spanned::new(annotation_span, StmtKind::Havoc(direction, vec![omega_var])),
+            Spanned::new(annotation_span, StmtKind::Validate(direction)),
+            Spanned::new(annotation_span, StmtKind::Assume(direction, next_omega_inv)),
+            iter,
+        ];
+
+        // conditions are checked with demonic if,
+        // we take sup or inf of the omega_inv before the demonic if
+        // to propagate the lower(upper) bound backwards for compositionality
+        // (if the conditions hold)
+
+        let buf = vec![
+            // (co)havoc n
+            Spanned::new(
+                annotation_span,
+                StmtKind::Havoc(direction.toggle(), vec![omega_var]),
+            ),
+            // (co)assert omega_inv
+            Spanned::new(
+                annotation_span,
+                StmtKind::Assert(direction, omega_inv.clone()),
+            ),
+            // conditions
+            Spanned::new(
+                annotation_span,
+                if direction == Direction::Down {
+                    StmtKind::Demonic(cond1, cond2)
+                } else {
+                    StmtKind::Angelic(cond1, cond2)
+                },
+            ),
+        ];
+
+        Ok((annotation_span, buf, None))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}

--- a/src/proof_rules/omega.rs
+++ b/src/proof_rules/omega.rs
@@ -1,3 +1,11 @@
+//! Encoding of omega invariant proof rule for lower/upper-bounds of expectations of a loop
+//!
+//! @omega_invariant takes the arguments:
+//!
+//! - `free_variable`: the variable that is used in the omega invariant
+//! - `omega_inv`: the omega invariant of the loop
+//!
+
 use std::fmt;
 
 use crate::{
@@ -14,7 +22,7 @@ use crate::{
     tyctx::TyCtx,
 };
 
-use super::Encoding;
+use super::{Encoding, EncodingGenerated};
 
 use super::util::*;
 
@@ -23,10 +31,10 @@ pub struct OmegaInvAnnotation(AnnotationInfo);
 impl OmegaInvAnnotation {
     pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
         let file = files
-            .add(SourceFilePath::Builtin, "omega_inv".to_string())
+            .add(SourceFilePath::Builtin, "omega_invariant".to_string())
             .id;
-
-        let name = Ident::with_dummy_file_span(Symbol::intern("omega_inv"), file);
+        // TODO: replace the dummy span with a proper span
+        let name = Ident::with_dummy_file_span(Symbol::intern("omega_invariant"), file);
 
         let omega_inv_param = intrinsic_param(file, "omega_inv", TyKind::EUReal, false);
         let free_var_param = intrinsic_param(file, "free_variable", TyKind::UInt, false);
@@ -92,7 +100,7 @@ impl Encoding for OmegaInvAnnotation {
         args: &[Expr],
         inner_stmt: &Stmt,
         direction: Direction,
-    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+    ) -> Result<EncodingGenerated, AnnotationError> {
         let [free_var, omega_inv] = two_args(args);
 
         let omega_var = if let ExprKind::Var(var_ref) = &free_var.kind {
@@ -183,7 +191,11 @@ impl Encoding for OmegaInvAnnotation {
             ),
         ];
 
-        Ok((annotation_span, buf, None))
+        Ok(EncodingGenerated {
+            span: annotation_span,
+            stmts: buf,
+            decls: None,
+        })
     }
 
     fn is_one_loop(&self) -> bool {

--- a/src/proof_rules/ost.rs
+++ b/src/proof_rules/ost.rs
@@ -1,0 +1,359 @@
+use std::fmt;
+
+use crate::{
+    ast::{
+        util::{FreeVariableCollector, ModifiedVariableCollector},
+        visit::VisitorMut,
+        BinOpKind, DeclKind, Direction, Expr, ExprBuilder, Files, Ident, ProcSpec, SourceFilePath,
+        Span, Spanned, Stmt, StmtKind, Symbol, TyKind, UnOpKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+
+use super::util::*;
+
+pub struct OSTAnnotation(AnnotationInfo);
+
+impl OSTAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files.add(SourceFilePath::Builtin, "ost".to_string()).id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("ost"), file);
+
+        let invariant_param = intrinsic_param(file, "inv", TyKind::SpecTy, false);
+        let past_invariant_param = intrinsic_param(file, "past_inv", TyKind::SpecTy, false);
+        let c_param = intrinsic_param(file, "c", TyKind::UReal, true);
+        let post_param = intrinsic_param(file, "post", TyKind::SpecTy, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(
+                vec![invariant_param, past_invariant_param, c_param, post_param],
+                file,
+            ),
+            span: Span::dummy_file_span(file),
+        };
+
+        OSTAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for OSTAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OSTAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for OSTAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [inv, past_inv, c, post] = mut_four_args(args);
+        resolve.visit_expr(inv)?;
+        resolve.visit_expr(past_inv)?;
+        resolve.visit_expr(c)?;
+        resolve.visit_expr(post)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        _direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let [inv, past_inv, c, post] = four_args(args);
+
+        let builder = ExprBuilder::new(annotation_span);
+        let mut free_var_collector = FreeVariableCollector::new();
+
+        // Collect and store the variables from the invariant
+        let inv_variables: Vec<Ident> = free_var_collector
+            .collect_and_clear(&mut inv.clone())
+            .into_iter()
+            .collect();
+
+        // Collect and store the variables from the past_invariant
+        let past_inv_variables = free_var_collector
+            .collect_and_clear(&mut past_inv.clone())
+            .into_iter()
+            .collect();
+
+        // Collect modified variables for havoc (exclude the variables that are declared in the loop)
+        let mut visitor = ModifiedVariableCollector::new();
+        visitor.visit_stmt(&mut inner_stmt.clone()).unwrap();
+        let modified_vars: Vec<Ident> = (&visitor.modified_variables - &visitor.declared_variables)
+            .into_iter()
+            .collect();
+
+        let (loop_guard, loop_body) = if let StmtKind::While(guard, body) = &inner_stmt.node {
+            (guard, body)
+        } else {
+            return Err(AnnotationError::NotOnWhile(
+                annotation_span,
+                self.name(),
+                inner_stmt.clone(),
+            ));
+        };
+
+        // Get the "init_{}" versions of the variable identifiers and declare them
+        let init_idents = get_init_idents(tcx, annotation_span, &modified_vars);
+
+        // Transform the [`Ident`]s into [`Expr`]s for assignments.
+        let init_exprs = init_idents
+            .iter()
+            .map(|ident| ident_to_expr(tcx, annotation_span, *ident))
+            .collect();
+
+        let init_assigns = multiple_assign(annotation_span, modified_vars.clone(), init_exprs);
+
+        // Replace all variables with the init versions in the invariant
+        let init_inv = to_init_expr(tcx, annotation_span, inv, &inv_variables);
+
+        // Replace all variables with the init versions in the past-invariant
+        let init_past_inv = to_init_expr(tcx, annotation_span, past_inv, &past_inv_variables);
+
+        // Construct ?(past_I < ∞)
+        let cond1_assert = builder.unary(
+            UnOpKind::Embed,
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Lt,
+                Some(TyKind::Bool),
+                past_inv.clone(),
+                builder.top_lit(&tcx.spec_ty().clone()),
+            ),
+        );
+
+        // ?(!guard ==> (I=f))
+        let harmonize_expr = builder.unary(
+            UnOpKind::Embed,
+            Some(tcx.spec_ty().clone()),
+            builder.binary(
+                BinOpKind::Impl,
+                Some(TyKind::Bool),
+                builder.unary(UnOpKind::Not, Some(TyKind::Bool), loop_guard.clone()),
+                builder.binary(BinOpKind::Eq, Some(TyKind::Bool), inv.clone(), post.clone()),
+            ),
+        );
+
+        // Collect variables used in the harmonization condition
+        let harmonize_expr_vars: Vec<Ident> = free_var_collector
+            .collect_and_clear(&mut harmonize_expr.clone())
+            .into_iter()
+            .collect();
+
+        // Condition 1: past_I < ∞
+        let cond1_proc = generate_proc(
+            annotation_span,
+            "lt_infinity",
+            params_from_idents(past_inv_variables, tcx),
+            vec![],
+            vec![],
+            vec![Spanned::new(
+                annotation_span,
+                StmtKind::Assert(Direction::Down, cond1_assert),
+            )],
+            Direction::Down,
+            tcx,
+        );
+
+        // Condition 2 : \Phi_{0}(past_I) <= past_I, so ert[P](0) <= past_I
+        let mut cond2_body = init_assigns.clone();
+        cond2_body.push(
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                hey_const(annotation_span, past_inv, tcx),
+            )
+            .unwrap(),
+        );
+
+        let cond2_proc = generate_proc(
+            annotation_span,
+            "past",
+            params_from_idents(init_idents.clone(), tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(init_past_inv),
+                ProcSpec::Ensures(builder.cast(TyKind::EUReal, builder.uint(0))),
+            ],
+            cond2_body,
+            Direction::Up,
+            tcx,
+        );
+
+        // Init assigns followed by the loop body
+        let mut cond3_body = init_assigns.clone();
+        cond3_body.extend(loop_body.clone());
+
+        // Encode |I(s)-I| as ite(I(s) <= I, I - I(s), I(s) - I)
+        let cond3_post = builder.ite(
+            Some(TyKind::EUReal),
+            builder.binary(
+                BinOpKind::Le,
+                Some(TyKind::Bool),
+                init_inv.clone(),
+                inv.clone(),
+            ),
+            builder.binary(
+                BinOpKind::Sub,
+                Some(TyKind::EUReal),
+                inv.clone(),
+                init_inv.clone(),
+            ),
+            builder.binary(
+                BinOpKind::Sub,
+                Some(TyKind::EUReal),
+                init_inv.clone(),
+                inv.clone(),
+            ),
+        );
+
+        let cond3_proc = generate_proc(
+            annotation_span,
+            "conditional_difference_bounded",
+            params_from_idents(init_idents.clone(), tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                // Cast c to EUReal otherwise the type is not a complete lattice
+                ProcSpec::Requires(builder.cast(TyKind::EUReal, c.clone())),
+                ProcSpec::Ensures(cond3_post),
+            ],
+            cond3_body,
+            Direction::Up,
+            tcx,
+        );
+
+        // Condition 4: !guard ==> (I = f)
+        let cond4_proc = generate_proc(
+            annotation_span,
+            "harmonize_I_f",
+            params_from_idents(harmonize_expr_vars, tcx),
+            vec![],
+            vec![],
+            vec![Spanned::new(
+                annotation_span,
+                StmtKind::Assert(Direction::Down, harmonize_expr),
+            )],
+            Direction::Down,
+            tcx,
+        );
+
+        // Condition 5: \Phi_f(I) < ∞
+        // The following block should be inserted before the iter encoding to check Phi < ∞
+        // instead of Phi <= ∞ which we normally achieve with just the coassume:
+        // coassume 0
+        // validate
+        // assume ∞
+
+        // Insert init assignments at the beginning
+        let mut cond5_body = init_assigns.clone();
+        cond5_body.extend(vec![
+            Spanned::new(annotation_span, StmtKind::Validate(Direction::Down)),
+            Spanned::new(
+                annotation_span,
+                StmtKind::Assume(Direction::Down, builder.top_lit(&TyKind::EUReal)),
+            ),
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                hey_const(annotation_span, inv, tcx),
+            )
+            .unwrap(),
+        ]);
+
+        let cond5_proc = generate_proc(
+            annotation_span,
+            "loopiter_lt_infty",
+            params_from_idents(init_idents.clone(), tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(builder.cast(TyKind::EUReal, builder.uint(0))),
+                ProcSpec::Ensures(post.clone()),
+            ],
+            cond5_body,
+            Direction::Up,
+            tcx,
+        );
+
+        // Condition 6: I <= \Phi_{post}(I)
+        let mut cond6_body = init_assigns;
+        cond6_body.push(
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                hey_const(annotation_span, inv, tcx),
+            )
+            .unwrap(),
+        );
+
+        let cond6_proc = generate_proc(
+            annotation_span,
+            "lower_bound",
+            params_from_idents(init_idents, tcx),
+            params_from_idents(modified_vars.clone(), tcx),
+            vec![
+                ProcSpec::Requires(init_inv),
+                ProcSpec::Ensures(post.clone()),
+            ],
+            cond6_body,
+            Direction::Down,
+            tcx,
+        );
+
+        // Call to the lower_bound proc from Condition 6
+        let proc_call = builder.call(
+            cond6_proc.name(),
+            modified_vars
+                .iter()
+                .map(|ident| ident_to_expr(tcx, annotation_span, *ident)),
+            tcx,
+        );
+
+        // Assign variables to return values of the "lower_bound" proc call
+        let buf = vec![Spanned::new(
+            annotation_span,
+            StmtKind::Assign(modified_vars, proc_call),
+        )];
+
+        Ok((
+            annotation_span,
+            buf,
+            Some(vec![
+                cond1_proc, cond2_proc, cond3_proc, cond4_proc, cond5_proc, cond6_proc,
+            ]),
+        ))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}

--- a/src/proof_rules/past.rs
+++ b/src/proof_rules/past.rs
@@ -1,0 +1,274 @@
+use std::fmt;
+
+use crate::{
+    ast::{
+        util::{FreeVariableCollector, ModifiedVariableCollector},
+        visit::VisitorMut,
+        BinOpKind, DeclKind, Direction, Expr, ExprBuilder, Files, Ident, ProcSpec, SourceFilePath,
+        Span, Spanned, Stmt, StmtKind, Symbol, TyKind, UnOpKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::Encoding;
+
+use super::util::*;
+
+pub struct PASTAnnotation(AnnotationInfo);
+
+impl PASTAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files.add(SourceFilePath::Builtin, "past".to_string()).id;
+
+        let name = Ident::with_dummy_file_span(Symbol::intern("past"), file);
+
+        let invariant_param = intrinsic_param(file, "inv", TyKind::SpecTy, false);
+        let eps_param = intrinsic_param(file, "eps", TyKind::UReal, true);
+        let k_param = intrinsic_param(file, "k", TyKind::UReal, true);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![invariant_param, eps_param, k_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        PASTAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for PASTAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PASTAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for PASTAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [inv, eps, k] = mut_three_args(args);
+        resolve.visit_expr(inv)?;
+        resolve.visit_expr(eps)?;
+        resolve.visit_expr(k)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        _direction: Direction,
+    ) -> Result<(Span, Vec<Stmt>, Option<Vec<DeclKind>>), AnnotationError> {
+        let [inv, eps, k] = three_args(args);
+        let builder = ExprBuilder::new(annotation_span);
+
+        let eps_val = lit_f64(eps);
+        let k_val = lit_f64(k);
+
+        if eps_val >= k_val {
+            return Err(AnnotationError::WrongArgument(
+                annotation_span,
+                eps.clone(),
+                String::from("eps must be smaller than k."),
+            ));
+        }
+
+        // Collect modified variables for havoc (exclude the variables that are declared in the loop)
+        let mut visitor = ModifiedVariableCollector::new();
+        visitor.visit_stmt(&mut inner_stmt.clone()).unwrap();
+        let modified_vars: Vec<Ident> = (&visitor.modified_variables - &visitor.declared_variables)
+            .into_iter()
+            .collect();
+
+        let mut free_var_collector = FreeVariableCollector::new();
+
+        // Collect and store the variables from the invariant
+        let inv_variables: Vec<Ident> = free_var_collector
+            .collect_and_clear(&mut inv.clone())
+            .into_iter()
+            .collect();
+
+        let (loop_guard, _) = if let StmtKind::While(guard, body) = &inner_stmt.node {
+            (guard, body)
+        } else {
+            return Err(AnnotationError::NotOnWhile(
+                annotation_span,
+                self.name(),
+                inner_stmt.clone(),
+            ));
+        };
+
+        // Get the "init_{}" versions of the variable identifiers and declare them
+        let init_idents = get_init_idents(tcx, annotation_span, &modified_vars);
+
+        // Transform the [`Ident`]s into [`Expr`]s for assignments.
+        let init_exprs = init_idents
+            .iter()
+            .map(|ident| ident_to_expr(tcx, annotation_span, *ident))
+            .collect();
+
+        let init_assigns = multiple_assign(annotation_span, modified_vars.clone(), init_exprs);
+
+        // Replace all variables with the init versions in the past-invariant
+        let init_inv = to_init_expr(tcx, annotation_span, inv, &inv_variables);
+
+        // ?([!guard] * inv <= k)
+        let cond1_expr = builder.unary(
+            UnOpKind::Embed,
+            Some(tcx.spec_ty().clone()),
+            builder.binary(
+                BinOpKind::Le,
+                Some(TyKind::Bool),
+                builder.binary(
+                    BinOpKind::Mul,
+                    Some(TyKind::EUReal),
+                    builder.unary(
+                        UnOpKind::Iverson,
+                        Some(TyKind::EUReal),
+                        builder.unary(UnOpKind::Not, Some(TyKind::Bool), loop_guard.clone()),
+                    ),
+                    inv.clone(),
+                ),
+                k.clone(),
+            ),
+        );
+
+        // Collect variables used in the first condition
+        let cond1_expr_vars: Vec<Ident> = free_var_collector
+            .collect_and_clear(&mut cond1_expr.clone())
+            .into_iter()
+            .collect();
+
+        let cond1_proc = generate_proc(
+            annotation_span,
+            "condition_1",
+            params_from_idents(cond1_expr_vars, tcx),
+            vec![],
+            vec![],
+            vec![Spanned::new(
+                annotation_span,
+                StmtKind::Assert(Direction::Down, cond1_expr),
+            )],
+            Direction::Down,
+            tcx,
+        );
+
+        // [guard] * k <= (([guard] * invariant) + [!guard])
+        let cond2_expr = builder.binary(
+            BinOpKind::Le,
+            Some(TyKind::Bool),
+            // [guard] * k
+            builder.binary(
+                BinOpKind::Mul,
+                Some(TyKind::EUReal),
+                // [guard]
+                builder.unary(UnOpKind::Iverson, Some(TyKind::EUReal), loop_guard.clone()),
+                k.clone(),
+            ),
+            // (([guard] * invariant) + [!guard])
+            builder.binary(
+                BinOpKind::Add,
+                Some(TyKind::EUReal),
+                // ([guard] * invariant)
+                builder.binary(
+                    BinOpKind::Mul,
+                    Some(TyKind::EUReal),
+                    builder.unary(UnOpKind::Iverson, Some(TyKind::EUReal), loop_guard.clone()),
+                    inv.clone(),
+                ),
+                // [!guard]
+                builder.unary(
+                    UnOpKind::Iverson,
+                    Some(TyKind::EUReal),
+                    builder.unary(UnOpKind::Not, Some(TyKind::Bool), loop_guard.clone()),
+                ),
+            ),
+        );
+
+        // Collect variables used in the second condition
+        let cond2_expr_vars: Vec<Ident> = free_var_collector
+            .collect_and_clear(&mut cond2_expr.clone())
+            .into_iter()
+            .collect();
+
+        let cond2_proc = generate_proc(
+            annotation_span,
+            "condition_2",
+            params_from_idents(cond2_expr_vars, tcx),
+            vec![],
+            vec![],
+            vec![Spanned::new(
+                annotation_span,
+                StmtKind::Assert(Direction::Down, cond2_expr),
+            )],
+            Direction::Down,
+            tcx,
+        );
+
+        // Condition 3: \Phi_0(I) <= [G] * (I - eps)
+        let mut cond3_body = init_assigns;
+        cond3_body.push(
+            encode_iter(
+                annotation_span,
+                inner_stmt,
+                hey_const(annotation_span, inv, tcx),
+            )
+            .unwrap(),
+        );
+
+        let cond3_pre = builder.binary(
+            BinOpKind::Mul,
+            Some(TyKind::EUReal),
+            builder.unary(UnOpKind::Iverson, Some(TyKind::EUReal), loop_guard.clone()),
+            builder.binary(BinOpKind::Sub, Some(TyKind::EUReal), init_inv, eps.clone()),
+        );
+
+        let cond3_proc = generate_proc(
+            annotation_span,
+            "past",
+            params_from_idents(init_idents, tcx),
+            params_from_idents(modified_vars, tcx),
+            vec![
+                ProcSpec::Requires(cond3_pre),
+                ProcSpec::Ensures(builder.cast(TyKind::EUReal, builder.uint(0))),
+            ],
+            cond3_body,
+            Direction::Up,
+            tcx,
+        );
+
+        Ok((
+            annotation_span,
+            vec![],
+            Some(vec![cond1_proc, cond2_proc, cond3_proc]),
+        ))
+    }
+
+    fn is_one_loop(&self) -> bool {
+        true
+    }
+}

--- a/src/proof_rules/tests.rs
+++ b/src/proof_rules/tests.rs
@@ -1,126 +1,16 @@
-//! Replacement of calls to procedures by their specification.
+use pretty_assertions::assert_eq;
 
-use std::rc::Rc;
-
-use crate::{
-    ast::{visit::VisitorMut, DeclKind, Direction, SourceFilePath, Span, Stmt, StmtKind},
-    driver::{Item, SourceUnit},
-    intrinsic::annotations::{AnnotationError, AnnotationKind},
-    tyctx::TyCtx,
-};
-
-use super::Encoding;
-pub struct EncCall<'tcx, 'sunit> {
-    tcx: &'tcx mut TyCtx,
-    source_units_buf: &'sunit mut Vec<Item<SourceUnit>>,
-    direction: Option<Direction>,
+fn remove_whitespace(s: &mut String) {
+    s.retain(|c| !c.is_whitespace());
 }
 
-impl<'tcx, 'sunit> EncCall<'tcx, 'sunit> {
-    pub fn new(tcx: &'tcx mut TyCtx, source_units_buf: &'sunit mut Vec<Item<SourceUnit>>) -> Self {
-        EncCall {
-            tcx,
-            source_units_buf,
-            direction: Option::None,
-        }
-    }
-}
+use crate::single_desugar_test;
+use crate::verify_test;
 
-impl<'tcx, 'sunit> VisitorMut for EncCall<'tcx, 'sunit> {
-    type Err = AnnotationError;
-
-    fn visit_decl(&mut self, decl: &mut DeclKind) -> Result<(), Self::Err> {
-        if let DeclKind::ProcDecl(decl_ref) = decl {
-            self.direction = Some(decl_ref.borrow().direction);
-            self.visit_proc(decl_ref)?;
-        }
-        Ok(())
-    }
-
-    fn visit_stmts(&mut self, stmts: &mut Vec<Stmt>) -> Result<(), Self::Err> {
-        // Check if the program consists of only one loop
-        let mut encoding: Option<(Rc<dyn Encoding>, Span)> = None;
-
-        let mut is_one_loop = true;
-        for s in &mut *stmts {
-            match &mut s.node {
-                StmtKind::Annotation(ident, _, _) => {
-                    if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
-                        self.tcx.get(*ident).unwrap().as_ref()
-                    {
-                        encoding = Some((anno_ref.clone(), s.span));
-                    }
-                }
-                StmtKind::Var(_) => {}
-                _ => {
-                    is_one_loop = false;
-                }
-            }
-        }
-        // If the annotated encoding only supports one loop programs throw an error
-        if let Some((enc, span)) = encoding {
-            if enc.is_one_loop() && !is_one_loop {
-                return Err(AnnotationError::OneLoopOnly(span, enc.name()));
-            }
-        }
-
-        for s in stmts {
-            self.visit_stmt(s)?;
-        }
-        Ok(())
-    }
-
-    fn visit_stmt(&mut self, s: &mut Stmt) -> Result<(), Self::Err> {
-        if let StmtKind::Annotation(ident, inputs, inner_stmt) = &mut s.node {
-            if let DeclKind::AnnotationDecl(AnnotationKind::Encoding(anno_ref)) =
-                self.tcx.get(*ident).unwrap().as_ref()
-            {
-                if let StmtKind::While(_, _) = inner_stmt.node {
-                } else {
-                    return Err(AnnotationError::NotOnWhile(s.span, *ident, s.clone()));
-                }
-
-                let (span, stmts, decls_opt) = anno_ref.transform(
-                    self.tcx,
-                    s.span,
-                    inputs,
-                    inner_stmt,
-                    self.direction
-                        .ok_or(AnnotationError::NotInProcedure(s.span, *ident))?,
-                )?;
-                s.span = span;
-                s.node = StmtKind::Block(stmts);
-                if let Some(decls) = decls_opt {
-                    let items: Vec<Item<SourceUnit>> = decls
-                        .into_iter()
-                        .map(|decl| SourceUnit::Decl(decl).wrap_item(&SourceFilePath::Generated))
-                        .collect();
-
-                    self.source_units_buf.extend(items)
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use pretty_assertions::assert_eq;
-
-    fn remove_whitespace(s: &mut String) {
-        s.retain(|c| !c.is_whitespace());
-    }
-
-    use crate::single_desugar_test;
-    use crate::verify_test;
-
-    #[test]
-    fn test_k_induction_transform() {
-        let mut test_string = String::from(
-            r#"
+#[test]
+fn test_k_induction_transform() {
+    let mut test_string = String::from(
+        r#"
             proc main() -> () 
                 pre ∞
                 post ∞
@@ -140,8 +30,8 @@ mod test {
                 }
             }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
             proc main() -> () {
                 var x: UInt
                 @k_induction(1, x)
@@ -150,15 +40,15 @@ mod test {
                 }
             }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
-    #[test]
-    fn test_bmc_transform() {
-        let mut test_string = String::from(
-            r#"
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
+#[test]
+fn test_unroll_transform() {
+    let mut test_string = String::from(
+        r#"
             proc main() -> () 
                 pre ∞
                 post ∞
@@ -175,26 +65,26 @@ mod test {
                 }
             }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
             proc main() -> () {
                 var x: UInt
-                @bmc(1, x)
+                @unroll(1, 1)
                 while 1 <= x {
                     x = x - 1
                 }
             }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
 
-    #[test]
-    fn test_omega_transform() {
-        let mut test_string = String::from(
-            r#"
+#[test]
+fn test_omega_transform() {
+    let mut test_string = String::from(
+        r#"
             proc main() -> () 
                 pre ∞
                 post ∞
@@ -228,26 +118,26 @@ mod test {
                 }
             }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
             proc main() -> () {
                 var x: UInt
-                @omega_inv(n,[n > x])
+                @omega_invariant(n,[n > x])
                 while 1 <= x {
                     x = x - 1
                 }
             }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
 
-    #[test]
-    fn test_ost_transform() {
-        let mut test_string = String::from(
-            r#"
+#[test]
+fn test_ost_transform() {
+    let mut test_string = String::from(
+        r#"
             proc lt_infinity(a: Bool) -> () {
                 assert ?(((cast(EUReal, 2) * [a]) < ∞))
             }
@@ -357,8 +247,8 @@ mod test {
                 { prob_choice, a, b, k = lower_bound(prob_choice, a, b, k) }
             }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
         proc optional_stopping(init_b: UInt, init_a: Bool) -> (b: UInt, a: Bool)
             pre init_b + [init_a]
             post b
@@ -381,16 +271,16 @@ mod test {
             }
         }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
 
-    #[test]
-    fn test_past_transform() {
-        let mut test_string = String::from(
-            r#"
+#[test]
+fn test_past_transform() {
+    let mut test_string = String::from(
+        r#"
             proc condition_1(x: UInt) -> () {
                 assert ?((([! ((1 <= x))] * cast(EUReal, (x + 1))) <= 10/10))
             }
@@ -422,8 +312,8 @@ mod test {
                 {  }
             }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
             proc main() -> () {
                 var x: UInt
                 @past(x+1, 0.5, 1.0)
@@ -432,16 +322,16 @@ mod test {
                 }
             }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
 
-    #[test]
-    fn test_ast_transform() {
-        let mut test_string = String::from(
-            r#"
+#[test]
+fn test_ast_transform() {
+    let mut test_string = String::from(
+        r#"
         proc prob_antitone(a: UReal, b: UReal) -> ()
             pre ?((a <= b))
             post ?(((5/10)[v -> a] >= (5/10)[v -> b]))
@@ -492,8 +382,8 @@ mod test {
             {  }
         }
         "#,
-        );
-        let source = r#"
+    );
+    let source = r#"
             proc main() -> () {
                 var x: UInt
                 @ast(true, x, v, 0.5, v)
@@ -502,15 +392,75 @@ mod test {
                 }
             }
         "#;
-        let mut res = single_desugar_test(source).unwrap();
-        remove_whitespace(&mut test_string);
-        remove_whitespace(&mut res);
-        assert_eq!(test_string, res);
-    }
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
 
-    #[test]
-    fn test_past_not_on_while() {
-        let source = r#"
+#[test]
+fn test_k_induction_nested_transform() {
+    let source = r#"
+            proc main() -> () {
+                var x: UInt
+                var y: UInt
+                @k_induction(1, x)
+                while 1 <= x {
+                    x = x - 1
+                    @k_induction(1, y)
+                    while 1 <= y {
+                        y = y - 1
+                    }
+                }
+            }
+        "#;
+
+    let mut test_string = String::from(
+        r#"
+            proc main() -> ()
+                pre ∞
+                post ∞
+            {
+                var x: UInt
+                var y: UInt
+                {
+                    assert cast(EUReal, x)
+                    havoc x, y
+                    validate
+                    assume cast(EUReal, x)
+                    if (1 <= x) {
+                        x = (x - 1)
+                        {
+                            assert cast(EUReal, y)
+                            havoc y
+                            validate
+                            assume cast(EUReal, y)
+                            if (1 <= y) {
+                                y = (y - 1)
+                                assert cast(EUReal, y)
+                                assume cast(EUReal, 0)
+                            } else {
+                                
+                            }
+                        }
+                        assert cast(EUReal, x)
+                        assume cast(EUReal, 0)
+                    } else {
+                        
+                    }
+                }
+            }
+        "#,
+    );
+    let mut res = single_desugar_test(source).unwrap();
+    remove_whitespace(&mut test_string);
+    remove_whitespace(&mut res);
+    assert_eq!(test_string, res);
+}
+
+#[test]
+fn test_past_not_on_while() {
+    let source = r#"
     proc main() -> () {
         var x: UInt
         @past(x+1, 0.5, 1.0)
@@ -518,26 +468,24 @@ mod test {
     }
 "#;
 
-        let err = verify_test(&source).0.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Error: The annotation `past` is not on a while statement"
-        );
-    }
-
-    #[test]
-    fn test_invariant_not_on_while() {
-        let source = r#"
+    let err = verify_test(&source).0.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Error: The annotation `past` is not on a while statement"
+    );
+}
+#[test]
+fn test_invariant_not_on_while() {
+    let source = r#"
         proc main2() -> () {
             var x: UInt
             @invariant(x)
             x = x + 1
         }
         "#;
-        let err = verify_test(&source).0.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Error: The annotation `invariant` is not on a while statement"
-        );
-    }
+    let err = verify_test(&source).0.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Error: The annotation `invariant` is not on a while statement"
+    );
 }

--- a/src/proof_rules/unroll.rs
+++ b/src/proof_rules/unroll.rs
@@ -1,0 +1,131 @@
+//! Encode the proof for refuting a lower/upper bound of an expectation of a loop by unrolling the loop k times
+//!
+//! @unroll takes the arguments:
+//!
+//! - `k`: the number of times the loop will be unrolled
+//! - `terminator`: the terminator of the loop
+
+use std::fmt;
+
+use crate::{
+    ast::{
+        visit::VisitorMut, Direction, Expr, ExprKind, Files, Ident, SourceFilePath, Span, Spanned,
+        Stmt, Symbol, TyKind,
+    },
+    front::{
+        resolve::{Resolve, ResolveError},
+        tycheck::{Tycheck, TycheckError},
+    },
+    intrinsic::annotations::{check_annotation_call, AnnotationError, AnnotationInfo},
+    tyctx::TyCtx,
+};
+
+use super::{Encoding, EncodingGenerated};
+
+use super::util::*;
+
+pub struct UnrollAnnotation(AnnotationInfo);
+
+impl UnrollAnnotation {
+    pub fn new(_tcx: &mut TyCtx, files: &mut Files) -> Self {
+        let file = files.add(SourceFilePath::Builtin, "unroll".to_string()).id;
+
+        // TODO: replace the dummy span with a proper span
+        let name = Ident::with_dummy_file_span(Symbol::intern("unroll"), file);
+
+        let k_param = intrinsic_param(file, "k", TyKind::UInt, true);
+        let invariant_param = intrinsic_param(file, "terminator", TyKind::SpecTy, false);
+
+        let anno_info = AnnotationInfo {
+            name,
+            inputs: Spanned::with_dummy_file_span(vec![k_param, invariant_param], file),
+            span: Span::dummy_file_span(file),
+        };
+
+        UnrollAnnotation(anno_info)
+    }
+}
+
+impl fmt::Debug for UnrollAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnrollAnnotation")
+            .field("annotation", &self.0)
+            .finish()
+    }
+}
+
+impl Encoding for UnrollAnnotation {
+    fn name(&self) -> Ident {
+        self.0.name
+    }
+
+    fn tycheck(
+        &self,
+        tycheck: &mut Tycheck<'_>,
+        call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), TycheckError> {
+        check_annotation_call(tycheck, call_span, &self.0, args)?;
+        Ok(())
+    }
+
+    fn resolve(
+        &self,
+        resolve: &mut Resolve<'_>,
+        _call_span: Span,
+        args: &mut [Expr],
+    ) -> Result<(), ResolveError> {
+        let [k, invariant] = mut_two_args(args);
+        resolve.visit_expr(k)?;
+        resolve.visit_expr(invariant)
+    }
+
+    fn transform(
+        &self,
+        tcx: &TyCtx,
+        annotation_span: Span,
+        args: &[Expr],
+        inner_stmt: &Stmt,
+        direction: Direction,
+    ) -> Result<EncodingGenerated, AnnotationError> {
+        let [k, terminator] = two_args(args);
+
+        let k: u128 = lit_u128(k);
+
+        if let ExprKind::Lit(lit) = &terminator.kind {
+            match direction {
+                Direction::Down => {
+                    if !lit.node.is_top() {
+                        tracing::warn!("Top terminator is not used with down direction!");
+                    }
+                }
+                Direction::Up => {
+                    if !lit.node.is_bot() {
+                        tracing::warn!("Bottom terminator is not used with up direction!");
+                    }
+                }
+            }
+        }
+
+        // Extend the loop k times without asserts (unlike k-induction) because bmc flag is set
+        let buf = encode_extend(
+            annotation_span,
+            inner_stmt,
+            k,
+            terminator,
+            direction,
+            true,
+            hey_const(annotation_span, terminator, tcx),
+        );
+
+        Ok(EncodingGenerated {
+            span: annotation_span,
+            stmts: buf,
+            decls: None,
+        })
+    }
+
+    fn is_one_loop(&self) -> bool {
+        false
+    }
+}

--- a/src/proof_rules/util.rs
+++ b/src/proof_rules/util.rs
@@ -1,0 +1,354 @@
+use std::cell::RefCell;
+
+use num::ToPrimitive;
+
+use crate::{
+    ast::{
+        DeclKind, DeclRef, Direction, Expr, ExprBuilder, ExprData, ExprKind, FileId, Ident,
+        LitKind, Param, ProcDecl, ProcSpec, Shared, Span, SpanVariant, Spanned, Stmt, StmtKind,
+        Symbol, TyKind, VarDecl, VarKind,
+    },
+    tyctx::TyCtx,
+};
+
+/// Encode the given specification
+pub fn encode_spec(
+    span: Span,
+    pre: &Expr,
+    post: &Expr,
+    variables: Vec<Ident>,
+    direction: Direction,
+) -> Vec<Stmt> {
+    vec![
+        Spanned::new(span, StmtKind::Assert(direction, pre.clone())),
+        Spanned::new(span, StmtKind::Havoc(direction, variables)),
+        Spanned::new(span, StmtKind::Validate(direction)),
+        Spanned::new(span, StmtKind::Assume(direction, post.clone())),
+    ]
+}
+
+/// Encode the extend step in k-induction and bmc recursively for k times
+/// # Arguments
+/// * `span` - The span of the new generated statement
+/// * `inner_stmt` - A While statement to be encoded
+/// * `k` - How many times the loop will be extended
+/// * `invariant` - The invariant which will be used in assert statements
+/// * `direction` - The direction of the statements in the extend
+/// * `bmc` - Whether the extension is for bmc of k-induction
+/// * `next_iter` - Parameter necessary for the recursion
+pub fn encode_extend(
+    span: Span,
+    inner_stmt: &Stmt,
+    k: u128,
+    invariant: &Expr,
+    direction: Direction,
+    bmc: bool,
+    next_iter: Vec<Stmt>,
+) -> Vec<Stmt> {
+    if k == 0 {
+        return next_iter;
+    }
+    let next_iter = encode_extend(
+        span,
+        inner_stmt,
+        k - 1,
+        invariant,
+        direction,
+        bmc,
+        next_iter,
+    );
+    if bmc {
+        vec![encode_iter(span, inner_stmt, next_iter).unwrap()]
+    } else {
+        vec![
+            Spanned::new(span, StmtKind::Assert(direction, invariant.clone())),
+            encode_iter(span, inner_stmt, next_iter).unwrap(),
+        ]
+    }
+}
+
+/// Encode one iteration of a while loop with an if then else statement
+pub fn encode_iter(span: Span, stmt: &Stmt, next_iter: Vec<Stmt>) -> Option<Stmt> {
+    if let StmtKind::While(expr, body) = &stmt.node {
+        let mut next_body = body.clone();
+        next_body.extend(next_iter);
+        return Some(Spanned::new(
+            span,
+            StmtKind::If(expr.clone(), next_body, vec![]),
+        ));
+    };
+    None
+}
+
+/// Constant program which always evaluates to the given expression
+pub fn hey_const(span: Span, expr: &Expr, tcx: &TyCtx) -> Vec<Stmt> {
+    let builder = ExprBuilder::new(span);
+    vec![
+        Spanned::new(span, StmtKind::Assert(Direction::Down, expr.clone())),
+        Spanned::new(
+            span,
+            StmtKind::Assume(Direction::Down, builder.bot_lit(tcx.spec_ty())),
+        ),
+    ]
+}
+
+pub fn new_ident_with_name(tcx: &TyCtx, ty: &TyKind, span: Span, name: &str) -> Ident {
+    let new_ident = Ident {
+        name: Symbol::intern(name),
+        span,
+    };
+
+    // If the init_variable is not already defined.
+    if tcx.get(new_ident).is_none() {
+        let var_decl = VarDecl {
+            name: new_ident,
+            ty: ty.clone(),
+            kind: VarKind::Input,
+            init: None,
+            span,
+        };
+        let decl = DeclRef::new(var_decl);
+        tcx.declare(DeclKind::VarDecl(decl));
+    }
+
+    new_ident
+}
+
+/// Get the init versions of the given idents and declare them
+pub fn get_init_idents(tcx: &TyCtx, span: Span, idents: &Vec<Ident>) -> Vec<Ident> {
+    let mut new_idents = vec![];
+    for ident in idents.iter() {
+        let ty = match tcx.get(*ident).unwrap().as_ref() {
+            DeclKind::VarDecl(var_ref) => var_ref.borrow().ty.clone(),
+            _ => panic!(),
+        };
+
+        let new_name = format!("init_{}", ident.name.to_owned());
+        let new_ident = Ident {
+            name: Symbol::intern(&new_name),
+            span: ident.span.variant(SpanVariant::Encoding),
+        };
+        new_idents.push(new_ident);
+
+        // If the init_variable is not already defined.
+        if tcx.get(new_ident).is_none() {
+            let var_decl = VarDecl {
+                name: new_ident,
+                ty: ty.clone(),
+                kind: VarKind::Input,
+                init: None,
+                span,
+            };
+            let decl = DeclRef::new(var_decl);
+            tcx.declare(DeclKind::VarDecl(decl.clone()));
+        }
+    }
+
+    new_idents
+}
+
+/// Construct multiple [`StmtKind::Assign`] expressions sequentially
+pub fn multiple_assign(span: Span, lhses: Vec<Ident>, rhses: Vec<Expr>) -> Vec<Stmt> {
+    let mut buf: Vec<Stmt> = vec![];
+    lhses.iter().zip(rhses).for_each(|(lhs, rhs)| {
+        let stmt = Spanned::new(span, StmtKind::Assign(vec![*lhs], rhs));
+        buf.push(stmt);
+    });
+    buf
+}
+
+/// Construct an variable [`Expr`] from the given [`Ident`]
+pub fn ident_to_expr(tcx: &TyCtx, span: Span, ident: Ident) -> Expr {
+    let ty = match tcx.get(ident).unwrap().as_ref() {
+        DeclKind::VarDecl(var_ref) => var_ref.borrow().ty.clone(),
+        _ => panic!(),
+    };
+    Shared::new(ExprData {
+        kind: ExprKind::Var(ident),
+        ty: Some(ty),
+        span,
+    })
+}
+
+/// Construct an expression from the given expression
+/// in which all variables given in the variables input are replaced by init versions of the corresponding variable
+pub fn to_init_expr(tcx: &TyCtx, span: Span, expr: &Expr, variables: &Vec<Ident>) -> Expr {
+    let builder = ExprBuilder::new(span);
+
+    // Construct "init_{}" versions of variables in the invariant parameters and transform them into expressions
+    let init_expressions: Vec<Expr> = get_init_idents(tcx, span, variables)
+        .iter()
+        .map(|ident| ident_to_expr(tcx, span, *ident))
+        .collect();
+
+    // To substitute the variables with init versions, create a mapping by zipping the two vectors
+    let init_mapping: Vec<(Ident, Expr)> = variables
+        .clone()
+        .into_iter()
+        .zip(init_expressions)
+        .collect();
+
+    // Construct the version of the invariant with all variables substituted by init versions
+    let new_expr: Expr = builder.subst(expr.clone(), init_mapping);
+
+    new_expr
+}
+
+/// Construct and declare a [`DeclKind::ProcDecl`] instance with the given arguments
+pub fn generate_proc(
+    span: Span,
+    name: &str,
+    inputs: Vec<Param>,
+    outputs: Vec<Param>,
+    spec: Vec<ProcSpec>,
+    body: Vec<Stmt>,
+    direction: Direction,
+    tcx: &TyCtx,
+) -> DeclKind {
+    let decl = DeclKind::ProcDecl(DeclRef::new(ProcDecl {
+        direction,
+        name: Ident::with_dummy_span(Symbol::intern(name)),
+        inputs: Spanned::new(span, inputs),
+        outputs: Spanned::new(span, outputs),
+        spec,
+        body: RefCell::new(Some(body)),
+        span,
+    }));
+
+    tcx.declare(decl.clone());
+
+    decl
+}
+
+pub fn one_arg(args: &[Expr]) -> [&Expr; 1] {
+    if let [a] = args {
+        [a]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn mut_one_arg(args: &mut [Expr]) -> [&mut Expr; 1] {
+    if let [a] = args {
+        [a]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn two_args(args: &[Expr]) -> [&Expr; 2] {
+    if let [a, b] = args {
+        [a, b]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn mut_two_args(args: &mut [Expr]) -> [&mut Expr; 2] {
+    if let [ref mut a, ref mut b] = args {
+        [a, b]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn three_args(args: &[Expr]) -> [&Expr; 3] {
+    if let [a, b, c] = args {
+        [a, b, c]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn mut_three_args(args: &mut [Expr]) -> [&mut Expr; 3] {
+    if let [a, b, c] = args {
+        [a, b, c]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn four_args(args: &[Expr]) -> [&Expr; 4] {
+    if let [a, b, c, d] = args {
+        [a, b, c, d]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn mut_four_args(args: &mut [Expr]) -> [&mut Expr; 4] {
+    if let [a, b, c, d] = args {
+        [a, b, c, d]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn five_args(args: &[Expr]) -> [&Expr; 5] {
+    if let [a, b, c, d, e] = args {
+        [a, b, c, d, e]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn mut_five_args(args: &mut [Expr]) -> [&mut Expr; 5] {
+    if let [ref mut a, ref mut b, ref mut c, ref mut d, ref mut e] = args {
+        [a, b, c, d, e]
+    } else {
+        unreachable!()
+    }
+}
+
+pub fn lit_f64(expr: &Expr) -> f64 {
+    if let ExprKind::Lit(lit) = &expr.kind {
+        match &lit.node {
+            LitKind::Frac(value) => {
+                return value.to_f64().unwrap();
+            }
+            LitKind::UInt(value) => {
+                return *value as f64;
+            }
+            _ => return 0.0,
+        }
+    };
+    unreachable!()
+}
+
+pub fn lit_u128(expr: &Expr) -> u128 {
+    if let ExprKind::Lit(lit) = &expr.kind {
+        if let LitKind::UInt(value) = &lit.node {
+            return *value;
+        }
+    };
+    unreachable!()
+}
+
+/// Construct a [`Param`] for intrinsic annotations
+pub fn intrinsic_param(file: FileId, name: &str, ty: TyKind, literal_only: bool) -> Param {
+    Param {
+        name: Ident::with_dummy_file_span(Symbol::intern(name), file),
+        ty: Box::new(ty),
+        literal_only,
+        span: Span::dummy_file_span(file),
+    }
+}
+
+/// Construct [`Param`]s with the given [`Ident`]s. The idents must be declared before.
+pub fn params_from_idents(idents: Vec<Ident>, tcx: &TyCtx) -> Vec<Param> {
+    let mut buf: Vec<Param> = vec![];
+    for ident in idents.iter() {
+        if let DeclKind::VarDecl(var_ref) = tcx.get(*ident).unwrap().as_ref() {
+            let var_ref = var_ref.clone();
+            let var = var_ref.borrow();
+
+            buf.push(Param {
+                name: *ident,
+                ty: Box::new(var.ty.clone()),
+                literal_only: false,
+                span: ident.span,
+            })
+        }
+    }
+    buf
+}

--- a/src/smt/mod.rs
+++ b/src/smt/mod.rs
@@ -197,6 +197,9 @@ fn ty_to_sort<'ctx>(ctx: &SmtCtx<'ctx>, ty: &TyKind) -> Sort<'ctx> {
             .get_sort(domain_ref.borrow().name)
             .unwrap()
             .clone(),
-        TyKind::Unresolved(_) | TyKind::None => panic!("invalid type"),
+
+        TyKind::SpecTy | TyKind::Unresolved(_) | TyKind::None => {
+            panic!("invalid type")
+        }
     }
 }

--- a/src/smt/symbolic.rs
+++ b/src/smt/symbolic.rs
@@ -57,7 +57,9 @@ impl<'ctx> Symbolic<'ctx> {
                 Symbolic::List(list)
             }
             TyKind::Domain(_) => Symbolic::Uninterpreted(value.clone()),
-            TyKind::Unresolved(_) | TyKind::None => unreachable!(),
+            TyKind::SpecTy | TyKind::Unresolved(_) | TyKind::None => {
+                unreachable!()
+            }
         }
     }
 

--- a/src/smt/translate_exprs.rs
+++ b/src/smt/translate_exprs.rs
@@ -93,6 +93,7 @@ impl<'smt, 'ctx> TranslateExprs<'smt, 'ctx> {
             TyKind::Tuple(_) => todo!(),
             TyKind::List(_) => Symbolic::List(self.t_list(expr)),
             TyKind::Domain(_) => Symbolic::Uninterpreted(self.t_uninterpreted(expr)),
+            TyKind::SpecTy => unreachable!(),
             TyKind::Unresolved(_) => unreachable!(),
             TyKind::None => unreachable!(),
         }
@@ -637,6 +638,7 @@ impl<'smt, 'ctx> TranslateExprs<'smt, 'ctx> {
                 }
                 TyKind::Tuple(_) => todo!(),
                 TyKind::List(element_ty) => ScopeSymbolic::fresh_list(self.ctx, ident, element_ty),
+                TyKind::SpecTy => unreachable!(),
                 TyKind::Unresolved(_) => todo!(),
                 TyKind::None => todo!(),
             },

--- a/tests/encodings/ast_rule_annotated.heyvl
+++ b/tests/encodings/ast_rule_annotated.heyvl
@@ -1,0 +1,23 @@
+// RUN: @caesar @file
+//
+// Test file to check the following pgcl program with caesar encodings
+// invariant = true variant = (3 * [!(x % 2 == 0)]) + ite(x >= 10, x - 10, 10 - x), probability function = 0.5, decrease function = 2
+
+proc main() -> ()
+{
+    var x: UInt
+    @ast(true, (3 * [!(x % 2 == 0)]) + ite(x >= 10, x - 10, 10 - x), v, 0.5, 2)
+    while x != 10 {
+        if x % 2 == 0{
+            var prob_choice: Bool
+            prob_choice = flip(1/2)
+            if prob_choice {
+                x = x - 2
+            } else {
+                x = x + 2
+            }
+        } else {
+            x = x + 1 
+        }
+    }
+}

--- a/tests/encodings/bmc_brp5-fail.heyvl
+++ b/tests/encodings/bmc_brp5-fail.heyvl
@@ -1,0 +1,29 @@
+// RUN: bash -c '! @caesar @file'
+// 
+// Test file to check refute_brp5_bmc.pgcl with caesar encodings
+// k = 14, invariant = totalFailed + 1
+
+coproc bounded_model_checking(init_toSend: UInt, init_sent: UInt, init_maxFailed: UInt, init_failed: UInt, init_totalFailed: UInt) -> (toSend: UInt, sent: UInt, maxFailed: UInt, failed: UInt, totalFailed: UInt)
+    pre init_totalFailed + 1
+    post totalFailed
+{
+    var prob_choice: Bool
+    toSend = init_toSend
+    sent = init_sent
+    maxFailed = init_maxFailed
+    failed = init_failed
+    totalFailed = init_totalFailed
+
+    @bmc(14, totalFailed + 1)
+    while (failed < maxFailed) && (sent < toSend) {
+        prob_choice = flip(0.9)
+        if prob_choice {
+            failed = 0
+            sent = sent + 1
+        } else {
+            failed = failed + 1
+            totalFailed = totalFailed + 1
+        }
+
+    } 
+}

--- a/tests/encodings/invariant_linear01.heyvl
+++ b/tests/encodings/invariant_linear01.heyvl
@@ -1,0 +1,21 @@
+// RUN: @caesar @file
+// Test file to check linear01.pgcl with caesar encodings
+// k = 1, invariant = "0.6 * x"
+
+coproc k_ind(init_x: UInt) -> (x: UInt)
+    pre 0.6 * init_x
+    post 0
+{
+    var prob_choice: Bool
+    x = init_x
+
+    @invariant(0.6 * x)
+    while 2 <= x {
+        prob_choice = flip((1/3))
+        if prob_choice {
+            x = x - 1
+        } else {
+            x = x - 2
+        }
+    }
+}

--- a/tests/encodings/kind_brp1.heyvl
+++ b/tests/encodings/kind_brp1.heyvl
@@ -1,0 +1,26 @@
+// RUN: @caesar @file
+// Test file to check brp1.pgcl with caesar encodings
+// k = 5, invariant = "[toSend <= 4] * (totalFailed + 1)) + ([!(toSend <= 4)] * ∞"
+
+coproc k_ind(toSend: UInt, init_sent: UInt, maxFailed: UInt, init_totalFailed: UInt) -> ( sent: UInt, failed: UInt, totalFailed: UInt)
+    pre ([toSend <= 4] * (init_totalFailed + 1)) + ([!(toSend <= 4)] * ∞)
+    post totalFailed
+{
+    
+    sent = init_sent
+    totalFailed = init_totalFailed
+
+    failed = 0
+
+    @k_induction(5, ([toSend <= 4] * (totalFailed + 1)) + ([!(toSend <= 4)] * ∞))
+    while (failed < maxFailed) && (sent < toSend) {
+        var prob_choice: Bool = flip(0.9)
+        if prob_choice {
+            failed = 0
+            sent = sent + 1
+        } else {
+            failed = failed + 1
+            totalFailed = totalFailed + 1
+        }
+    }
+}

--- a/tests/encodings/kind_linear01.heyvl
+++ b/tests/encodings/kind_linear01.heyvl
@@ -1,0 +1,21 @@
+// RUN: @caesar @file
+// Test file to check linear01.pgcl with caesar encodings
+// k = 1, invariant = "0.6 * x"
+
+coproc k_ind(init_x: UInt) -> (x: UInt)
+    pre 0.6 * init_x
+    post 0
+{
+    var prob_choice: Bool
+    x = init_x
+
+    @k_induction(1, 0.6 * x)
+    while 2 <= x {
+        prob_choice = flip((1/3))
+        if prob_choice {
+            x = x - 1
+        } else {
+            x = x - 2
+        }
+    }
+}

--- a/tests/encodings/simple_omega_invariant.heyvl
+++ b/tests/encodings/simple_omega_invariant.heyvl
@@ -1,0 +1,12 @@
+proc omega(init_x: UInt) -> (x: UInt)
+    pre init_x
+    post 0
+{
+    x = init_x
+
+    @omega_inv(n,[x<=n] * x)
+    while 0 <= x {
+        tick 1
+        x = x - 1
+    }
+}

--- a/tests/loop-rules/ast-rule.heyvl
+++ b/tests/loop-rules/ast-rule.heyvl
@@ -71,7 +71,7 @@ coproc V_wp_superinvariant(init_x: UInt) -> (x: UInt)
     } else {}
 }
 
-// [I] * [G] * (p o V) <= \s. wp[P]([V < V(s) - d(V(s))])(s)
+// [I] * [G] * (p o V) <= \s. wp[P]([V <= V(s) - d(V(s))])(s)
 proc progress_condition(init_x: UInt) -> (x: UInt)
     pre [true] * ([!(init_x == 10)] * 0.5)
     post [((3 * [!(x % 2 == 0)]) + ite(x >= 10, x - 10, 10 - x)) <= (((3 * [!(init_x % 2 == 0)]) + ite(init_x >= 10, init_x - 10, 10 - init_x)) - 2)]


### PR DESCRIPTION
- Added Annotations
- SpecTy is a placeholder type that is replaced by the actual specification type while resolving
- New Proof Rule Encodings:
  - invariant
  - k-induction
  - bounded model checking
  - omega invariants
  - optional stopping theorem
  - positive almost sure termination (Chakarov 2013)
  - almost sure termination (McIver 2018)
