### PR TITLE
fix: nested one-loop encodings

### DIFF
--- a/src/intrinsic/annotations.rs
+++ b/src/intrinsic/annotations.rs
@@ -1,4 +1,4 @@
-//! Intrinsic annotations 
+//! Intrinsic annotations
 use std::rc::Rc;
 
 use ariadne::ReportKind;

--- a/src/proof_rules/mciver_ast.rs
+++ b/src/proof_rules/mciver_ast.rs
@@ -158,7 +158,6 @@ impl Encoding for ASTAnnotation {
         let modified_or_used: IndexSet<Ident> = visitor
             .modified_variables
             .union(&visitor.used_variables)
-            .into_iter()
             .cloned()
             .collect();
 
@@ -170,7 +169,6 @@ impl Encoding for ASTAnnotation {
             - &visitor
                 .declared_variables
                 .union(&visitor.modified_variables)
-                .into_iter()
                 .cloned()
                 .collect::<IndexSet<Ident>>())
             .into_iter()

--- a/src/proof_rules/omega.rs
+++ b/src/proof_rules/omega.rs
@@ -137,7 +137,7 @@ impl Encoding for OmegaInvAnnotation {
         )
         .unwrap();
 
-        //Phi_x(0)
+        // Phi_x(0)
         let null_iter = encode_iter(
             annotation_span,
             inner_stmt,


### PR DESCRIPTION
Fix for the bug that allows the annotations that should only be used on *one-loop programs* to be used in nested statements such as:

```heyvl
if x < 10 {
  @ast(...)
  while x > 0 {
    ...
  }
}
```

This must be forbidden.