### PR TITLE
vscode-ext: fix flickering view rendering after server restart

### DIFF
--- a/vscode-ext/src/CaesarClient.ts
+++ b/vscode-ext/src/CaesarClient.ts
@@ -115,15 +115,13 @@ export class CaesarClient {
         }));
 
         // listen to onDidSaveTextDocument events
-        const autoVerify: string = CaesarConfig.get(ConfigurationConstants.automaticVerification);
-        if (autoVerify === "onsave") {
-            context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
-                if (document.languageId !== "heyvl") {
-                    return;
-                }
-                void this.verify(document);
-            }));
-        }
+        this.context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
+            if (document.languageId !== "heyvl" && CaesarConfig.get(ConfigurationConstants.automaticVerification) !== "onsave") {
+                return;
+            }
+            void this.verify(document);
+        }));
+
     }
 
     private async createClient(recommendInstallation: boolean): Promise<LanguageClient | null> {

--- a/vscode-ext/src/CaesarClient.ts
+++ b/vscode-ext/src/CaesarClient.ts
@@ -113,6 +113,17 @@ export class CaesarClient {
                 this.needsRestart = true;
             }
         }));
+
+        // listen to onDidSaveTextDocument events
+        const autoVerify: string = CaesarConfig.get(ConfigurationConstants.automaticVerification);
+        if (autoVerify === "onsave") {
+            context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
+                if (document.languageId !== "heyvl") {
+                    return;
+                }
+                void this.verify(document);
+            }));
+        }
     }
 
     private async createClient(recommendInstallation: boolean): Promise<LanguageClient | null> {
@@ -171,16 +182,7 @@ export class CaesarClient {
             }
         }));
 
-        // listen to onDidSaveTextDocument events
-        const autoVerify: string = CaesarConfig.get(ConfigurationConstants.automaticVerification);
-        if (autoVerify === "onsave") {
-            context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((document) => {
-                if (document.languageId !== "heyvl") {
-                    return;
-                }
-                void this.verify(document);
-            }));
-        }
+
 
         // check server version
         context.subscriptions.push(client.onNotification("custom/caesarReady", (event) => {


### PR DESCRIPTION
This PR fixes the flickering bug which occurs when the server is restarted multiple times.

- *Cause*:  The `start` method of the client calls the `createClient` method, which registered the `onDidSaveTextDocument` callback. Hence every restart registers a copy of the same callback. Therefore if the server is restarted $n$ times, the same `onDidSaveTextDocument` callback is being called $n$ times when the document is saved. this makes the server verify the same document $n$ times consecutively which ultimately causes the flickering of the view elements.

- *Fix*: The `onDidSaveTextDocument` callback register is moved to the `CaesarClient`s constructor (where also command callbacks are registered) instead of the `createClient` method