### PR TITLE
Use cmd to run integration tests on windows

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -71,6 +71,11 @@ fn main() {
             config.add_search_path(test_file);
         }
 
+        // The default shell is bash, which is not available on Windows.
+        if cfg!(target_os = "windows") {
+            config.shell = "cmd.exe".to_string();
+        }
+
         config
             .constants
             .insert("caesar".to_owned(), CAESAR_PATH.to_owned());


### PR DESCRIPTION
Previously the integration tests failed under windows with errors of the form
```
FAIL :: six-sided-die.heyvl

test failed: unsuccessful program execution whilst running test

command 'C:\Users\Eloem\Documents\projects\caesar\target\debug\caesar.exe \\?\C:\Users\Eloem\Documents\projects\caesar\tests\six-sided-die.heyvl'
exited with code '127'

NOTE: the program 'C:\Users\Eloem\Documents\projects\caesar\target\debug\caesar.exe \\?\C:\Users\Eloem\Documents\projects\caesar\tests\six-sided-die.heyvl'
emitted text on standard error:

<stderr>:

  1|      /bin/bash: line 1: C:UsersEloemDocumentsprojectscaesartargetdebugcaesar.exe: command not found

</stderr>
```