### PR TITLE
pgcl2heyvl: fix bmc example with correct k

### DIFF
--- a/pgcl/examples-heyvl/refute-rabin3_bmc.heyvl
+++ b/pgcl/examples-heyvl/refute-rabin3_bmc.heyvl
@@ -9,7 +9,7 @@ coproc main(init_i: UInt, init_n: UInt, init_d: UInt, init_phase: UInt) -> (i: U
     n = init_n
     d = init_d
     phase = init_phase
-    @unroll(5, 0)
+    @unroll(15, 0)
     while (1 < i) || (phase == 1) {
         if phase == 0 {
             n = i

--- a/pgcl/examples/refute-rabin3_bmc.pgcl
+++ b/pgcl/examples/refute-rabin3_bmc.pgcl
@@ -1,4 +1,4 @@
-// ARGS: --encoding "encode-bmc" --calculus "wp" --post "[i=1]" --pre "[1<i &  i < 4 & phase=0] * (2/3) + [not (1<i & i<4 & phase=0)]*1" --k 5
+// ARGS: --encoding "encode-bmc" --calculus "wp" --post "[i=1]" --pre "[1<i &  i < 4 & phase=0] * (2/3) + [not (1<i & i<4 & phase=0)]*1" --k 15
 
 nat i;
 nat n; # Does not need to be initialized


### PR DESCRIPTION
This PR fixes the `refute-rabin3_bmc.pgcl`example by using the correct `k` value of 15. It may take significantly longer than the default timeout limit to find a counterexample; therefore, a timeout of at least 100 seconds is recommended.