### PR TITLE
Update z3.rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "z3"
 version = "0.12.1"
-source = "git+https://github.com/Philipp15b/z3.rs.git?rev=bdd501ca1e50785365b875b3438a0cf953cffbfc#bdd501ca1e50785365b875b3438a0cf953cffbfc"
+source = "git+https://github.com/Philipp15b/z3.rs.git?rev=473cb83d85cbce92b837a1667693ca9ca38c046c#473cb83d85cbce92b837a1667693ca9ca38c046c"
 dependencies = [
  "log",
  "num",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "z3-sys"
 version = "0.8.1"
-source = "git+https://github.com/Philipp15b/z3.rs.git?rev=bdd501ca1e50785365b875b3438a0cf953cffbfc#bdd501ca1e50785365b875b3438a0cf953cffbfc"
+source = "git+https://github.com/Philipp15b/z3.rs.git?rev=473cb83d85cbce92b837a1667693ca9ca38c046c#473cb83d85cbce92b837a1667693ca9ca38c046c"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,9 @@ harness = false
 opt-level = 3
 
 [patch.crates-io]
-z3 = { git = 'https://github.com/Philipp15b/z3.rs.git', rev = 'bdd501ca1e50785365b875b3438a0cf953cffbfc' }
-z3-sys = { git = 'https://github.com/Philipp15b/z3.rs.git', rev = 'bdd501ca1e50785365b875b3438a0cf953cffbfc' }
+z3 = { git = 'https://github.com/Philipp15b/z3.rs.git', rev = '473cb83d85cbce92b837a1667693ca9ca38c046c' }
+z3-sys = { git = 'https://github.com/Philipp15b/z3.rs.git', rev = '473cb83d85cbce92b837a1667693ca9ca38c046c' }
 # to work on z3.rs locally, clone it into the main directory and use the following directive instead:
-# z3 = { path = 'z3.rs/z3' }
 
 # see https://github.com/heim-rs/darwin-libproc/pull/3#issuecomment-1645444056
 darwin-libproc = { git = "https://github.com/Orycterope/darwin-libproc.git", rev = "f73ddb1002d51ae74c1b41670fae56bd5896b7a3" }


### PR DESCRIPTION
CMake version 4.0 requires that no versions older than 3.5 are supported. This problem breaks the CI tests and build scripts since newest version of cmake is used. To resolve this issue, the Z3 submodule in the z3.rs points to a fork of z3 where the minimum required version has been updated manually. This PR updates the z3.rs dependency to a newer commit which has the updated submodule.

Closes #72 .