### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,5 +1,9 @@
 name: github pages
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/moves-rwth/caesar/security/code-scanning/17](https://github.com/moves-rwth/caesar/security/code-scanning/17)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it needs `contents: read` to check out the repository and `pages: write` to deploy to GitHub Pages. These permissions will be explicitly set to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
