### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
 on: [push, pull_request]
 
 name: Rust
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/moves-rwth/caesar/security/code-scanning/18](https://github.com/moves-rwth/caesar/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow and will explicitly set the `contents` permission to `read`. This is sufficient for the tasks performed in the workflow, as it only needs to read the repository contents to run tests, format code, and perform linting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
