### PR TITLE
Add Config File for VS Code Dev Containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+
+RUN apt-get update && apt-get install -y cmake llvm-dev libclang-dev clang lld

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+    "name": "Rust",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}


### PR DESCRIPTION
This PR adds a config file for VS Code Dev Containers extension.

In order to use this do the following:
- Install Docker
- Install VS Code Dev Containers extension
- Run the command "Dev Containers: Open Folder in Container.." and select the caesar folder.

This will configure a development environment that runs in a docker container built with the config and Dockerfile provided in the repository.