### PR TITLE
fix: unknown icon next to domain decls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashMap,
     ffi::OsString,
     io,
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
     path::PathBuf,
     process::ExitCode,
     sync::{Arc, Mutex},
@@ -23,7 +23,7 @@ use crate::{
     tyctx::TyCtx,
     vc::vcgen::Vcgen,
 };
-use ast::{visit::VisitorMut, DeclKind, Diagnostic, FileId};
+use ast::{visit::VisitorMut, Diagnostic, FileId};
 use clap::{crate_description, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use driver::{Item, SourceUnit, VerifyUnit};
 use intrinsic::{annotations::init_calculi, distributions::init_distributions, list::init_lists};
@@ -722,8 +722,8 @@ pub fn apply_encodings(
         .map_err(|ann_err| ann_err.diagnostic())?;
     }
 
-    for source_unit in &new_source_units {
-        server.register_source_unit(source_unit.name())?;
+    for source_unit in &mut new_source_units {
+        server.register_source_unit(source_unit)?;
     }
 
     source_units.extend(new_source_units);
@@ -821,12 +821,7 @@ fn verify_files_main(
 
     // Register all relevant source units with the server
     for source_unit in &mut source_units {
-        let name = source_unit.name().clone();
-        if let SourceUnit::Decl(DeclKind::ProcDecl(_)) = source_unit.enter().deref() {
-            // If the source unit is a proc declaration, register it with the server
-            // so that it can be used in the LSP server.
-            server.register_source_unit(&name)?;
-        }
+        server.register_source_unit(source_unit)?;
     }
 
     // explain high-level HeyVL if requested

--- a/src/servers/cli.rs
+++ b/src/servers/cli.rs
@@ -9,7 +9,7 @@ use ariadne::ReportKind;
 
 use crate::{
     ast::{Diagnostic, FileId, Files, SourceFilePath, StoredFile},
-    driver::{SmtVcCheckResult, SourceUnitName},
+    driver::{Item, SmtVcCheckResult, SourceUnit, SourceUnitName},
     smt::translate_exprs::TranslateExprs,
     vc::explain::VcExplanation,
     InputOptions, VerifyError,
@@ -84,7 +84,10 @@ impl Server for CliServer {
         Ok(())
     }
 
-    fn register_source_unit(&mut self, _name: &SourceUnitName) -> Result<(), VerifyError> {
+    fn register_source_unit(
+        &mut self,
+        _source_unit: &mut Item<SourceUnit>,
+    ) -> Result<(), VerifyError> {
         // Not relevant for CLI
         Ok(())
     }

--- a/src/servers/lsp.rs
+++ b/src/servers/lsp.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
+    ops::Deref,
     pin::Pin,
     sync::{Arc, Mutex},
 };
@@ -18,8 +19,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    ast::{Diagnostic, FileId, Files, SourceFilePath, Span, StoredFile},
-    driver::{SmtVcCheckResult, SourceUnitName},
+    ast::{DeclKind, Diagnostic, FileId, Files, SourceFilePath, Span, StoredFile},
+    driver::{Item, SmtVcCheckResult, SourceUnit, SourceUnitName},
     smt::translate_exprs::TranslateExprs,
     vc::explain::VcExplanation,
     version::caesar_semver_version,
@@ -348,10 +349,16 @@ impl Server for LspServer {
         Ok(())
     }
 
-    fn register_source_unit(&mut self, name: &SourceUnitName) -> Result<(), VerifyError> {
-        self.statuses.update_status(name, VerifyStatus::Todo);
-        self.publish_verify_statuses()
-            .map_err(VerifyError::ServerError)?;
+    fn register_source_unit(
+        &mut self,
+        source_unit: &mut Item<SourceUnit>,
+    ) -> Result<(), VerifyError> {
+        let name = source_unit.name().clone();
+        if let SourceUnit::Decl(DeclKind::ProcDecl(_)) = source_unit.enter().deref() {
+            self.statuses.update_status(&name, VerifyStatus::Todo);
+            self.publish_verify_statuses()
+                .map_err(VerifyError::ServerError)?;
+        }
         Ok(())
     }
 

--- a/src/servers/mod.rs
+++ b/src/servers/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     ast::{Diagnostic, FileId, Files, Span, SpanVariant, StoredFile},
-    driver::{SmtVcCheckResult, SourceUnitName},
+    driver::{Item, SmtVcCheckResult, SourceUnit, SourceUnitName},
     smt::translate_exprs::TranslateExprs,
     vc::explain::VcExplanation,
     VerifyError,
@@ -143,7 +143,10 @@ pub trait Server: Send {
     fn add_vc_explanation(&mut self, explanation: VcExplanation) -> Result<(), VerifyError>;
 
     /// Register a source unit span with the server.
-    fn register_source_unit(&mut self, name: &SourceUnitName) -> Result<(), VerifyError>;
+    fn register_source_unit(
+        &mut self,
+        source_unit: &mut Item<SourceUnit>,
+    ) -> Result<(), VerifyError>;
 
     /// Register a verify unit span as the current verifying with the server.
     fn set_ongoing_unit(&mut self, name: &SourceUnitName) -> Result<(), VerifyError>;

--- a/src/servers/test.rs
+++ b/src/servers/test.rs
@@ -1,8 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
-    ast::{Diagnostic, FileId, Files, StoredFile},
-    driver::{SmtVcCheckResult, SourceUnitName},
+    ast::{DeclKind, Diagnostic, FileId, Files, StoredFile},
+    driver::{Item, SmtVcCheckResult, SourceUnit, SourceUnitName},
     smt::translate_exprs::TranslateExprs,
     vc::explain::VcExplanation,
     VerifyCommand, VerifyError,
@@ -55,8 +58,14 @@ impl Server for TestServer {
         Ok(())
     }
 
-    fn register_source_unit(&mut self, name: &SourceUnitName) -> Result<(), VerifyError> {
-        self.statuses.update_status(name, VerifyStatus::Todo);
+    fn register_source_unit(
+        &mut self,
+        source_unit: &mut Item<SourceUnit>,
+    ) -> Result<(), VerifyError> {
+        let name = source_unit.name().clone();
+        if let SourceUnit::Decl(DeclKind::ProcDecl(_)) = source_unit.enter().deref() {
+            self.statuses.update_status(&name, VerifyStatus::Todo);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This PR fixes a visual bug that causes an unknown icon to be displayed next to domain declarations. 

Cause: 
The lsp server registers source units to the client (vscode extension) in the beginning of each verification process. Domain declarations are also source units. When the client does not receive a verification result for the span of the domain declaration, it displays an unknown result icon. 

This fix solves the issue by only registering proc declarations to the client.