### PR TITLE
annotations: fix shadowing issue

### DIFF
--- a/src/front/resolve.rs
+++ b/src/front/resolve.rs
@@ -3,8 +3,6 @@
 //! in this place. Resolution is therefore concerned with creating and resolving
 //! variable scopes.
 
-use std::rc::Rc;
-
 use ariadne::ReportKind;
 
 use crate::{
@@ -13,7 +11,7 @@ use crate::{
         DeclKind, DeclRef, Diagnostic, DomainDecl, DomainSpec, Expr, ExprKind, FuncDecl, Ident,
         Label, ProcDecl, Span, Stmt, StmtKind, Symbol, TyKind, VarDecl, VarKind,
     },
-    scope_map::ScopeMap,
+    scope_map::{ScopeEntry, ScopeMap},
     tyctx::TyCtx,
 };
 
@@ -219,22 +217,22 @@ impl<'tcx> VisitorMut for Resolve<'tcx> {
             StmtKind::Annotation(_, ref mut ident, ref mut args, ref mut inner_stmt) => {
                 // Resolve the annotation ident to the declaration
                 // Here we only look through annotation declarations therefore other declarations do not shadow annotations
-                match self
-                    .tcx
-                    .get_statement_annotations()
-                    .get(&ident.name)
-                    .map(Rc::as_ref)
-                {
-                    Some(DeclKind::AnnotationDecl(intrin)) => {
-                        *ident = intrin.name(); // Resolve to the declaration ident
-                        let intrin = intrin.clone(); // clone so we can mutably borrow self
-                        intrin.resolve(self, s.span, args)?;
-                    }
-                    _ => return Err(ResolveError::NotFound(*ident)), // Either not declared or not declared as an annotation,
-                                                                     // This case is same as None since we only look through annotations
-                }
+                let intrin = self.scope_map.find_map(&ident.name, |entry| match entry {
+                    ScopeEntry::Value(v) => self.tcx.get(*v).and_then(|decl| match decl.as_ref() {
+                        DeclKind::AnnotationDecl(intrin) => Some(intrin.clone()),
+                        _ => None,
+                    }),
+                    ScopeEntry::Deleted => None,
+                });
 
-                self.with_subscope(|this| this.visit_stmt(inner_stmt))
+                match intrin {
+                    Some(intrin) => {
+                        *ident = intrin.name(); // Resolve to the declaration ident
+                        intrin.resolve(self, s.span, args)?;
+                        self.with_subscope(|this| this.visit_stmt(inner_stmt))
+                    }
+                    _ => Err(ResolveError::NotFound(*ident)),
+                }
             }
             StmtKind::Label(ident) => self.declare(DeclKind::LabelDecl(*ident)),
             _ => walk_stmt(self, s),
@@ -314,4 +312,47 @@ fn resolve_builtin_ty(ident: Ident) -> Option<TyKind> {
         _ => return None,
     };
     Some(kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::driver::commands::verify::verify_test;
+
+    #[test]
+    fn test_issue_101_invariant_annotation_not_shadowed_by_local_name() {
+        let source = r#"
+        coproc main() -> () {
+            var invariant: EUReal = 0
+            @invariant(invariant)
+            while true {
+                invariant = invariant + 1
+            }
+        }
+        "#;
+        let res = verify_test(source).0;
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_issue_102_invariant_annotation_with_undeclared_function_reports_undeclared() {
+        let source = r#"
+        domain Invariants {
+            func invariant(x: Bool): EUReal = 0
+        }
+
+        coproc main() -> () {
+            var declared: Bool = true
+            @invariant(undeclared(declared))
+            while true {
+                declared = true
+            }
+        }
+        "#;
+        let res = verify_test(source).0;
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains("Name `undeclared` is not declared"));
+    }
 }

--- a/src/scope_map.rs
+++ b/src/scope_map.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 /// An entry in the map of at each scope level. Either there is a value, or we
 /// explicitly remember that the entry has been deleted on the current level.
 #[derive(Debug)]
-enum ScopeEntry<V> {
+pub enum ScopeEntry<V> {
     Value(V),
     Deleted,
 }
@@ -105,23 +105,43 @@ where
         }
     }
 
+    /// Iterate over entries with key `key` from inner to outer scope and return
+    /// the first mapped result that is [`Some`].
+    pub fn find_map<Q, T>(
+        &self,
+        key: &Q,
+        mut f: impl FnMut(&ScopeEntry<V>) -> Option<T>,
+    ) -> Option<T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        debug_assert!(!self.scopes.is_empty());
+        for map in self.scopes.iter().rev() {
+            if let Some(entry) = map.get(key) {
+                if let Some(res) = f(entry) {
+                    return Some(res);
+                }
+            }
+        }
+        None
+    }
+
     /// Retrieve an element from the map.
     pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        debug_assert!(!self.scopes.is_empty());
-        let entry = self
-            .scopes
-            .iter()
-            .rev()
-            .flat_map(|map| map.get(key))
-            .next()?;
-        match entry {
-            ScopeEntry::Value(v) => Some(v),
-            ScopeEntry::Deleted => None,
+        for map in self.scopes.iter().rev() {
+            if let Some(entry) = map.get(key) {
+                return match entry {
+                    ScopeEntry::Value(v) => Some(v),
+                    ScopeEntry::Deleted => None,
+                };
+            }
         }
+        None
     }
 
     /// Does this map contain the given key?

--- a/src/tyctx.rs
+++ b/src/tyctx.rs
@@ -9,7 +9,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::{ast::FuncDecl, intrinsic::annotations::AnnotationKind};
+use crate::ast::FuncDecl;
 use crate::{
     ast::{DeclKind, DeclRef, DomainDecl, Ident, LitKind, Span, Symbol, TyKind, VarKind},
     intrinsic::distributions::DistributionProc,
@@ -155,19 +155,6 @@ impl TyCtx {
             LitKind::Infinity => TyKind::EUReal,
             LitKind::Bool(_) => TyKind::Bool,
         }
-    }
-
-    /// Get all annotation declarations that can be used on top of statements. These are slicing and encoding annotations.
-    pub fn get_statement_annotations(&self) -> IndexMap<Symbol, Rc<DeclKind>> {
-        IndexMap::from_iter(self.declarations.borrow().iter().flat_map(|(ident, decl)| {
-            if let DeclKind::AnnotationDecl(
-                AnnotationKind::Slicing(_) | AnnotationKind::Encoding(_),
-            ) = decl.deref()
-            {
-                return Some((ident.name, decl.clone()));
-            }
-            None
-        }))
     }
 
     pub fn get_distributions(&self) -> IndexMap<Ident, Rc<DistributionProc>> {


### PR DESCRIPTION
This PR fixes the following issues by resolving annotations to only intrinsic annotation declarations, skipping the current scope. Hence other declaration kinds can't shadow annotation declarations anymore.
- fixes #67 
- fixes #101 
- fixes #102 
